### PR TITLE
Add Telemeter to Openshift Templates

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,4 +17,4 @@ jsonnet -J vendor -m environments/kubernetes/manifests environments/kubernetes/m
 rm -rf environments/openshift/manifests
 mkdir environments/openshift/manifests
 
-jsonnet -J vendor environments/openshift/main.jsonnet | gojsontoyaml > environments/openshift/manifests/thanos-template.yaml
+jsonnet -J vendor environments/openshift/main.jsonnet | gojsontoyaml > environments/openshift/manifests/observatorium-template.yaml

--- a/environments/kubernetes/kube-thanos.libsonnet
+++ b/environments/kubernetes/kube-thanos.libsonnet
@@ -36,9 +36,26 @@ local deployment = k.apps.v1.deployment;
     receive+: {
       service+:
         service.mixin.metadata.withNamespace(namespace),
-      statefulSet+:
-        sts.mixin.metadata.withNamespace(namespace) +
-        sts.mixin.spec.withReplicas(3),
+      statefulSet+: {
+        metadata+: {
+          namespace: namespace,
+        },
+        spec+: {
+          replicas: 3,
+          template+: {
+            spec+: {
+              // This patch should probably move upstream to kube-thanos
+              containers: [
+                super.containers[0] {
+                  args+: [
+                    '--tsdb.retention=6h',
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
     },
   },
 }

--- a/environments/kubernetes/manifests/telemeter-secret.yaml
+++ b/environments/kubernetes/manifests/telemeter-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+data:
+  rhd.client_id: ""
+  rhd.password: ""
+  rhd.url: ""
+  rhd.username: ""
+kind: Secret
+metadata:
+  labels:
+    k8s-app: telemeter-server
+  name: telemeter-server
+  namespace: observatorium
+type: Opaque

--- a/environments/kubernetes/manifests/telemeter-serviceMonitor.yaml
+++ b/environments/kubernetes/manifests/telemeter-serviceMonitor.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    endpoint: metrics
+    k8s-app: telemeter-server
+  name: telemeter-server
+  namespace: observatorium
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    port: internal
+    scheme: https
+    tlsConfig:
+      caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+      serverName: telemeter-server.observatorium.svc
+  jobLabel: k8s-app
+  selector:
+    matchLabels:
+      k8s-app: telemeter-server

--- a/environments/kubernetes/manifests/telemeter-serviceMonitorFederate.yaml
+++ b/environments/kubernetes/manifests/telemeter-serviceMonitorFederate.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    endpoint: federate
+    k8s-app: telemeter-server
+  name: telemeter-server-federate
+  namespace: observatorium
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
+    interval: 15s
+    params:
+      match[]:
+      - '{__name__=~".*"}'
+    path: /federate
+    port: internal
+    scheme: https
+    tlsConfig:
+      caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+      serverName: telemeter-server.observatorium.svc
+  jobLabel: k8s-app
+  selector:
+    matchLabels:
+      k8s-app: telemeter-server

--- a/environments/kubernetes/manifests/thanos-receive-statefulSet.yaml
+++ b/environments/kubernetes/manifests/thanos-receive-statefulSet.yaml
@@ -23,6 +23,7 @@ spec:
         - --remote-write.address=0.0.0.0:19291
         - --objstore.config=$(OBJSTORE_CONFIG)
         - --tsdb.path=/var/thanos/tsdb
+        - --tsdb.retention=6h
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:

--- a/environments/kubernetes/telemeter.libsonnet
+++ b/environments/kubernetes/telemeter.libsonnet
@@ -30,16 +30,4 @@
       },
     },
   },
-} + {
-  local ts = super.telemeterServer,
-  telemeterServer:: {
-    [k]: ts[k]
-    for k in std.objectFields(ts)
-    // This array must be sorted for `std.setMember` to work.
-    if !std.setMember(k, [
-      'secret',
-      'serviceMonitor',
-      'serviceMonitorFederate',
-    ])
-  },
 }

--- a/environments/openshift/kube-thanos.libsonnet
+++ b/environments/openshift/kube-thanos.libsonnet
@@ -95,12 +95,12 @@ local list = import 'telemeter/lib/list.libsonnet';
           value: 'telemeter',
         },
         {
-          name: 'THAONS_IMAGE',
-          value: 'improbable/thanos:v0.5.0',
+          name: 'THANOS_IMAGE',
+          value: 'improbable/thanos',
         },
         {
           name: 'THANOS_IMAGE_TAG',
-          value: 'dummy',  // We don't actually use this, but need it for OpenShift.
+          value: 'v0.6.0-rc.0',
         },
         {
           name: 'THANOS_QUERIER_REPLICAS',

--- a/environments/openshift/kube-thanos.libsonnet
+++ b/environments/openshift/kube-thanos.libsonnet
@@ -8,7 +8,7 @@ local list = import 'telemeter/lib/list.libsonnet';
 {
   thanos+:: {
     variables+: {
-      image: '${IMAGE}',
+      image: '${THANOS_IMAGE}:${THANOS_IMAGE_TAG}',
       objectStorageConfig+: {
         name: '${THANOS_CONFIG_SECRET}',
         key: 'thanos.yaml',

--- a/environments/openshift/main.jsonnet
+++ b/environments/openshift/main.jsonnet
@@ -17,7 +17,9 @@ local app =
 
         parameters:
           $.thanos.template.parameters +
-          $.telemeterServer.list.parameters,
+          $.telemeterServer.list.parameters + [
+            { name: 'TELEMETER_FORWARD_URL', value: '' },
+          ],
       },
   };
 

--- a/environments/openshift/main.jsonnet
+++ b/environments/openshift/main.jsonnet
@@ -7,56 +7,55 @@ local app =
   (import 'kube-thanos.libsonnet') +
   {
     // This generates the Template kind that OpenShift requires
-    local t = super.thanos,
-    thanos+:: {
-      template:
-        local objects = {
-          ['querier-' + name]: t.querier[name]
-          for name in std.objectFields(t.querier)
-        } + {
-          ['store-' + name]: t.store[name]
-          for name in std.objectFields(t.store)
-        } + {
-          ['receive-' + name]: t.receive[name]
-          for name in std.objectFields(t.receive)
-        };
+    local thanos = super.thanos,
 
-        list.asList('thanos', objects, [
-          {
-            name: 'NAMESPACE',
-            value: 'telemeter',
-          },
-          {
-            name: 'IMAGE',
-            value: 'improbable/thanos:v0.5.0',
-          },
-          {
-            name: 'IMAGE_TAG',
-            value: 'dummy',  // We don't actually use this, but need it for OpenShift.
-          },
-          {
-            name: 'THANOS_QUERIER_REPLICAS',
-            value: '3',
-          },
-          {
-            name: 'THANOS_STORE_REPLICAS',
-            value: '5',
-          },
-          {
-            name: 'THANOS_RECEIVE_REPLICAS',
-            value: '5',
-          },
-          {
-            name: 'THANOS_CONFIG_SECRET',
-            value: 'thanos-objectstorage',
-          },
-          {
-            name: 'THANOS_S3_SECRET',
-            value: 'telemeter-thanos-stage-s3',
-          },
-        ]),
-    },
+    template:
+      local objects = {
+        ['querier-' + name]: thanos.querier[name]
+        for name in std.objectFields(thanos.querier)
+      } + {
+        ['store-' + name]: thanos.store[name]
+        for name in std.objectFields(thanos.store)
+      } + {
+        ['receive-' + name]: thanos.receive[name]
+        for name in std.objectFields(thanos.receive)
+      };
+
+      list.asList('observatorium', objects, [
+        {
+          name: 'NAMESPACE',
+          value: 'telemeter',
+        },
+        {
+          name: 'IMAGE',
+          value: 'improbable/thanos:v0.5.0',
+        },
+        {
+          name: 'IMAGE_TAG',
+          value: 'dummy',  // We don't actually use this, but need it for OpenShift.
+        },
+        {
+          name: 'THANOS_QUERIER_REPLICAS',
+          value: '3',
+        },
+        {
+          name: 'THANOS_STORE_REPLICAS',
+          value: '5',
+        },
+        {
+          name: 'THANOS_RECEIVE_REPLICAS',
+          value: '5',
+        },
+        {
+          name: 'THANOS_CONFIG_SECRET',
+          value: 'thanos-objectstorage',
+        },
+        {
+          name: 'THANOS_S3_SECRET',
+          value: 'telemeter-thanos-stage-s3',
+        },
+      ]),
   };
 
 // Output only the template
-app.thanos.template
+app.template

--- a/environments/openshift/main.jsonnet
+++ b/environments/openshift/main.jsonnet
@@ -5,56 +5,20 @@ local list = import 'telemeter/lib/list.libsonnet';
 
 local app =
   (import 'kube-thanos.libsonnet') +
+  (import 'telemeter.libsonnet') +
   {
-    // This generates the Template kind that OpenShift requires
     local thanos = super.thanos,
 
     template:
-      local objects = {
-        ['querier-' + name]: thanos.querier[name]
-        for name in std.objectFields(thanos.querier)
-      } + {
-        ['store-' + name]: thanos.store[name]
-        for name in std.objectFields(thanos.store)
-      } + {
-        ['receive-' + name]: thanos.receive[name]
-        for name in std.objectFields(thanos.receive)
-      };
+      list.asList('observatorium', {}, []) + {
+        objects:
+          $.thanos.template.objects +
+          $.telemeterServer.list.objects,
 
-      list.asList('observatorium', objects, [
-        {
-          name: 'NAMESPACE',
-          value: 'telemeter',
-        },
-        {
-          name: 'IMAGE',
-          value: 'improbable/thanos:v0.5.0',
-        },
-        {
-          name: 'IMAGE_TAG',
-          value: 'dummy',  // We don't actually use this, but need it for OpenShift.
-        },
-        {
-          name: 'THANOS_QUERIER_REPLICAS',
-          value: '3',
-        },
-        {
-          name: 'THANOS_STORE_REPLICAS',
-          value: '5',
-        },
-        {
-          name: 'THANOS_RECEIVE_REPLICAS',
-          value: '5',
-        },
-        {
-          name: 'THANOS_CONFIG_SECRET',
-          value: 'thanos-objectstorage',
-        },
-        {
-          name: 'THANOS_S3_SECRET',
-          value: 'telemeter-thanos-stage-s3',
-        },
-      ]),
+        parameters:
+          $.thanos.template.parameters +
+          $.telemeterServer.list.parameters,
+      },
   };
 
 // Output only the template

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -187,12 +187,159 @@ objects:
         - emptyDir: {}
           name: data
     volumeClaimTemplates: []
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      service.alpha.openshift.io/serving-cert-secret-name: telemeter-server-shared
+    labels:
+      k8s-app: telemeter-server
+    name: telemeter-server
+    namespace: ${NAMESPACE}
+  spec:
+    clusterIP: None
+    ports:
+    - name: external
+      port: 8443
+      targetPort: external
+    - name: internal
+      port: 8081
+      targetPort: internal
+    - name: cluster
+      port: 8082
+      targetPort: cluster
+    selector:
+      k8s-app: telemeter-server
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: telemeter-server
+    namespace: ${NAMESPACE}
+- apiVersion: apps/v1beta2
+  kind: StatefulSet
+  metadata:
+    name: telemeter-server
+    namespace: ${NAMESPACE}
+  spec:
+    podManagementPolicy: Parallel
+    replicas: 3
+    selector:
+      matchLabels:
+        k8s-app: telemeter-server
+    serviceName: telemeter-server
+    template:
+      metadata:
+        labels:
+          k8s-app: telemeter-server
+      spec:
+        containers:
+        - command:
+          - /usr/bin/telemeter-server
+          - --join=telemeter-server
+          - --name=$(NAME)
+          - --listen=0.0.0.0:8443
+          - --listen-internal=0.0.0.0:8081
+          - --listen-cluster=0.0.0.0:8082
+          - --shared-key=/etc/pki/service/tls.key
+          - --tls-key=/etc/pki/service/tls.key
+          - --tls-crt=/etc/pki/service/tls.crt
+          - --internal-tls-key=/etc/pki/service/tls.key
+          - --internal-tls-crt=/etc/pki/service/tls.crt
+          - --authorize=${AUTHORIZE_URL}
+          - --authorize-issuer-url=$(RHD_URL)
+          - --authorize-client-id=$(RHD_CLIENT_ID)
+          - --authorize-username=$(RHD_USERNAME)
+          - --authorize-password=$(RHD_PASSWORD)
+          - --whitelist={__name__="up"}
+          - --whitelist={__name__="cluster_version"}
+          - --whitelist={__name__="cluster_version_available_updates"}
+          - --whitelist={__name__="cluster_operator_up"}
+          - --whitelist={__name__="cluster_operator_conditions"}
+          - --whitelist={__name__="cluster_version_payload"}
+          - --whitelist={__name__="cluster_version_payload_errors"}
+          - --whitelist={__name__="instance:etcd_object_counts:sum"}
+          - --whitelist={__name__="alerts",alertstate="firing"}
+          - --whitelist={__name__="code:apiserver_request_count:rate:sum"}
+          - --whitelist={__name__="kube_pod_status_ready:etcd:sum"}
+          - --whitelist={__name__="kube_pod_status_ready:image_registry:sum"}
+          - --whitelist={__name__="cluster:capacity_cpu_cores:sum"}
+          - --whitelist={__name__="cluster:capacity_memory_bytes:sum"}
+          - --whitelist={__name__="cluster:cpu_usage_cores:sum"}
+          - --whitelist={__name__="cluster:memory_usage_bytes:sum"}
+          - --whitelist={__name__="openshift:cpu_usage_cores:sum"}
+          - --whitelist={__name__="openshift:memory_usage_bytes:sum"}
+          - --whitelist={__name__="cluster:node_instance_type_count:sum"}
+          - --elide-label=prometheus_replica
+          - --forward-url=http://thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive
+          env:
+          - name: NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: RHD_URL
+            valueFrom:
+              secretKeyRef:
+                key: rhd.url
+                name: telemeter-server
+          - name: RHD_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: rhd.username
+                name: telemeter-server
+          - name: RHD_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: rhd.password
+                name: telemeter-server
+          - name: RHD_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                key: rhd.client_id
+                name: telemeter-server
+          image: ${IMAGE}:${IMAGE_TAG}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8443
+              scheme: HTTPS
+          name: telemeter-server
+          ports:
+          - containerPort: 8443
+            name: external
+          - containerPort: 8081
+            name: internal
+          - containerPort: 8082
+            name: cluster
+          readinessProbe:
+            httpGet:
+              path: /healthz/ready
+              port: 8443
+              scheme: HTTPS
+          resources:
+            limits:
+              cpu: ${TELEMETER_SERVER_CPU_LIMIT}
+              memory: ${TELEMETER_SERVER_MEMORY_LIMIT}
+            requests:
+              cpu: ${TELEMETER_SERVER_CPU_REQUEST}
+              memory: ${TELEMETER_SERVER_MEMORY_REQUEST}
+          volumeMounts:
+          - mountPath: /etc/pki/service
+            name: telemeter-server-tls
+            readOnly: false
+        serviceAccountName: telemeter-server
+        volumes:
+        - name: secret-telemeter-server
+          secret:
+            secretName: telemeter-server
+        - name: telemeter-server-tls
+          secret:
+            secretName: telemeter-server-shared
 parameters:
 - name: NAMESPACE
   value: telemeter
-- name: IMAGE
+- name: THAONS_IMAGE
   value: improbable/thanos:v0.5.0
-- name: IMAGE_TAG
+- name: THANOS_IMAGE_TAG
   value: dummy
 - name: THANOS_QUERIER_REPLICAS
   value: "3"
@@ -204,3 +351,19 @@ parameters:
   value: thanos-objectstorage
 - name: THANOS_S3_SECRET
   value: telemeter-thanos-stage-s3
+- name: AUTHORIZE_URL
+  value: https://api.openshift.com/api/accounts_mgmt/v1/cluster_registrations
+- name: NAMESPACE
+  value: observatorium
+- name: IMAGE
+  value: quay.io/openshift/origin-telemeter
+- name: IMAGE_TAG
+  value: v4.0
+- name: TELEMETER_SERVER_CPU_REQUEST
+  value: 100m
+- name: TELEMETER_SERVER_CPU_LIMIT
+  value: "1"
+- name: TELEMETER_SERVER_MEMORY_REQUEST
+  value: 500Mi
+- name: TELEMETER_SERVER_MEMORY_LIMIT
+  value: 1Gi

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -222,7 +222,7 @@ objects:
     namespace: ${NAMESPACE}
   spec:
     podManagementPolicy: Parallel
-    replicas: 3
+    replicas: 10
     selector:
       matchLabels:
         k8s-app: telemeter-server

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -88,6 +88,7 @@ objects:
           - --remote-write.address=0.0.0.0:19291
           - --objstore.config=$(OBJSTORE_CONFIG)
           - --tsdb.path=/var/thanos/tsdb
+          - --tsdb.retention=6h
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -331,7 +331,7 @@ objects:
           - --whitelist={__name__="openshift:memory_usage_bytes:sum"}
           - --whitelist={__name__="cluster:node_instance_type_count:sum"}
           - --elide-label=prometheus_replica
-          - --forward-url=http://thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive
+          - --forward-url=${TELEMETER_FORWARD_URL}
           env:
           - name: NAME
             valueFrom:
@@ -428,3 +428,5 @@ parameters:
   value: 500Mi
 - name: TELEMETER_SERVER_MEMORY_LIMIT
   value: 1Gi
+- name: TELEMETER_FORWARD_URL
+  value: ""

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -397,10 +397,10 @@ objects:
 parameters:
 - name: NAMESPACE
   value: telemeter
-- name: THAONS_IMAGE
-  value: improbable/thanos:v0.5.0
+- name: THANOS_IMAGE
+  value: improbable/thanos
 - name: THANOS_IMAGE_TAG
-  value: dummy
+  value: v0.6.0-rc.0
 - name: THANOS_QUERIER_REPLICAS
   value: "3"
 - name: THANOS_STORE_REPLICAS

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -188,6 +188,19 @@ objects:
           name: data
     volumeClaimTemplates: []
 - apiVersion: v1
+  data:
+    rhd.client_id: ""
+    rhd.password: ""
+    rhd.url: ""
+    rhd.username: ""
+  kind: Secret
+  metadata:
+    labels:
+      k8s-app: telemeter-server
+    name: telemeter-server
+    namespace: ${NAMESPACE}
+  type: Opaque
+- apiVersion: v1
   kind: Service
   metadata:
     annotations:
@@ -215,6 +228,53 @@ objects:
   metadata:
     name: telemeter-server
     namespace: ${NAMESPACE}
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    labels:
+      endpoint: metrics
+      k8s-app: telemeter-server
+    name: telemeter-server
+    namespace: ${NAMESPACE}
+  spec:
+    endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      port: internal
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        serverName: telemeter-server.${NAMESPACE}.svc
+    jobLabel: k8s-app
+    selector:
+      matchLabels:
+        k8s-app: telemeter-server
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    labels:
+      endpoint: federate
+      k8s-app: telemeter-server
+    name: telemeter-server-federate
+    namespace: ${NAMESPACE}
+  spec:
+    endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      honorLabels: true
+      interval: 15s
+      params:
+        match[]:
+        - '{__name__=~".*"}'
+      path: /federate
+      port: internal
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        serverName: telemeter-server.${NAMESPACE}.svc
+    jobLabel: k8s-app
+    selector:
+      matchLabels:
+        k8s-app: telemeter-server
 - apiVersion: apps/v1beta2
   kind: StatefulSet
   metadata:

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -26,7 +26,7 @@ objects:
           - --query.replica-label=replica
           - --store=dnssrv+_grpc._tcp.thanos-store.${NAMESPACE}.svc.cluster.local
           - --store=dnssrv+_grpc._tcp.thanos-receive.${NAMESPACE}.svc.cluster.local
-          image: ${IMAGE}
+          image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
           name: thanos-querier
 - apiVersion: v1
   kind: Service
@@ -105,7 +105,7 @@ objects:
               secretKeyRef:
                 key: aws_secret_access_key
                 name: ${THANOS_S3_SECRET}
-          image: ${IMAGE}
+          image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
           name: thanos-receive
           ports:
           - containerPort: 10901
@@ -175,7 +175,7 @@ objects:
               secretKeyRef:
                 key: aws_secret_access_key
                 name: ${THANOS_S3_SECRET}
-          image: ${IMAGE}
+          image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
           name: thanos-store
           ports:
           - containerPort: 10901

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: thanos
+  name: observatorium
 objects:
 - apiVersion: apps/v1
   kind: Deployment

--- a/environments/openshift/telemeter.libsonnet
+++ b/environments/openshift/telemeter.libsonnet
@@ -6,6 +6,20 @@ local list = import 'telemeter/lib/list.libsonnet';
     statefulSet+: {
       spec+: {
         replicas: 10,
+
+        template+: {
+          spec+: {
+            containers: [
+              c {
+                command: [
+                  if std.startsWith(c, '--forward-url=') then '--forward-url=${TELEMETER_FORWARD_URL}' else c
+                  for c in super.command
+                ],
+              }
+              for c in super.containers
+            ],
+          },
+        },
       },
     },
   },

--- a/environments/openshift/telemeter.libsonnet
+++ b/environments/openshift/telemeter.libsonnet
@@ -2,6 +2,14 @@ local list = import 'telemeter/lib/list.libsonnet';
 
 (import '../kubernetes/telemeter.libsonnet') +
 {
+  telemeterServer+:: {
+    statefulSet+: {
+      spec+: {
+        replicas: 10,
+      },
+    },
+  },
+} + {
   local ts = super.telemeterServer,
   telemeterServer+:: {
     list: list.asList('telemeter', ts, [])

--- a/environments/openshift/telemeter.libsonnet
+++ b/environments/openshift/telemeter.libsonnet
@@ -1,0 +1,22 @@
+local list = import 'telemeter/lib/list.libsonnet';
+
+(import '../kubernetes/telemeter.libsonnet') +
+{
+  local ts = super.telemeterServer,
+  telemeterServer+:: {
+    list: list.asList('telemeter', ts, [])
+          + list.withAuthorizeURL($._config)
+          + list.withNamespace($._config)
+          + list.withServerImage($._config)
+          + list.withResourceRequestsAndLimits('telemeter-server', $._config.telemeterServer.resourceRequests, $._config.telemeterServer.resourceLimits),
+  },
+
+  _config+:: {
+    telemeterServer+: {
+      whitelist+: (import 'telemeter/metrics.jsonnet'),
+      elideLabels+: [
+        'prometheus_replica',
+      ],
+    },
+  },
+}


### PR DESCRIPTION
The two files for telemeter and kube-thanos expose their own OpenShift templates:
```
environments/openshift/telemeter.libsonnet
environments/openshift/kube-thanos.libsonnet
```

Then in `environments/openshift/main.libsonnet` we just merge both Templates together.

/cc @brancz @aditya-konarde