### PR TITLE
jsonnet: bump telemeter dep

### DIFF
--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -330,6 +330,7 @@ objects:
           - --whitelist={__name__="cluster_operator_conditions"}
           - --whitelist={__name__="cluster_version_payload"}
           - --whitelist={__name__="cluster_version_payload_errors"}
+          - --whitelist={__name__="cluster_installer"}
           - --whitelist={__name__="instance:etcd_object_counts:sum"}
           - --whitelist={__name__="alerts",alertstate="firing"}
           - --whitelist={__name__="code:apiserver_request_count:rate:sum"}

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -28,7 +28,7 @@
                     "subdir": "jsonnet/telemeter"
                 }
             },
-            "version": "ce206ba40660c4ff39d4d01c795049724d60eff3"
+            "version": "0bacffce75d23d34035f56cc1c2d3cd71ad543cd"
         },
         {
             "name": "prometheus-operator",


### PR DESCRIPTION
This commit bumps the Telemeter dependency in order to incorporate a
newly added metric that tracks the cluster installation method.

cc @metalmatze @kakkoyun 