### PR TITLE
Use a unique image tag for thanos-receive-controller image

### DIFF
--- a/components/thanos-receive-controller.libsonnet
+++ b/components/thanos-receive-controller.libsonnet
@@ -77,7 +77,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         local env = container.envType;
 
         local c =
-          container.new($.thanos.receiveController.deployment.metadata.name, 'quay.io/observatorium/thanos-receive-controller:latest') +
+          container.new($.thanos.receiveController.deployment.metadata.name, 'quay.io/observatorium/thanos-receive-controller:master-2019-07-17-1085ff9') +
           container.withArgs([
             '--configmap-name=%s' % $.thanos.receiveController.configmap.metadata.name,
             '--configmap-generated-name=%s-generated' % $.thanos.receiveController.configmap.metadata.name,

--- a/environments/kubernetes/manifests/thanos-receive-controller-deployment.yaml
+++ b/environments/kubernetes/manifests/thanos-receive-controller-deployment.yaml
@@ -26,6 +26,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/observatorium/thanos-receive-controller:latest
+        image: quay.io/observatorium/thanos-receive-controller:master-2019-07-17-1085ff9
         name: thanos-receive-controller
       serviceAccount: thanos-receive-controller

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -90,7 +90,7 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: quay.io/observatorium/thanos-receive-controller:latest
+          image: quay.io/observatorium/thanos-receive-controller:master-2019-07-17-1085ff9
           name: thanos-receive-controller
         serviceAccount: thanos-receive-controller
 - apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Closes #14 
With https://github.com/observatorium/thanos-receive-controller/pull/18 merged we can now move away from using `:latest`.