### PR TITLE
.drone.yml: add basic CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,17 @@
+---
+kind: pipeline
+name: build
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: test
+  pull: always
+  image: quay.io/coreos/jsonnet-ci
+  commands:
+  - find . -type f -not -path './vendor/*' \( -name '*.libsonnet' -o -name '*.jsonnet' \) | xargs -L1 jsonnetfmt --test
+  - jb install
+  - ./build.sh
+  - git diff --exit-code

--- a/environments/kubernetes/manifests/thanos-querier-deployment.yaml
+++ b/environments/kubernetes/manifests/thanos-querier-deployment.yaml
@@ -19,7 +19,14 @@ spec:
       - args:
         - query
         - --query.replica-label=replica
+        - --grpc-address=0.0.0.0:10901
+        - --http-address=0.0.0.0:9090
         - --store=dnssrv+_grpc._tcp.thanos-store.observatorium.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.thanos-receive.observatorium.svc.cluster.local
         image: improbable/thanos:v0.6.0-rc.0
         name: thanos-querier
+        ports:
+        - containerPort: 10901
+          name: grpc
+        - containerPort: 9090
+          name: http

--- a/environments/kubernetes/manifests/thanos-receive-statefulSet.yaml
+++ b/environments/kubernetes/manifests/thanos-receive-statefulSet.yaml
@@ -23,6 +23,7 @@ spec:
       - args:
         - receive
         - --grpc-address=0.0.0.0:10901
+        - --http-address=0.0.0.0:10902
         - --remote-write.address=0.0.0.0:19291
         - --objstore.config=$(OBJSTORE_CONFIG)
         - --tsdb.path=/var/thanos/tsdb

--- a/environments/kubernetes/manifests/thanos-store-statefulSet.yaml
+++ b/environments/kubernetes/manifests/thanos-store-statefulSet.yaml
@@ -21,6 +21,7 @@ spec:
         - store
         - --data-dir=/var/thanos/store
         - --grpc-address=0.0.0.0:10901
+        - --http-address=0.0.0.0:10902
         - --objstore.config=$(OBJSTORE_CONFIG)
         env:
         - name: OBJSTORE_CONFIG
@@ -33,6 +34,8 @@ spec:
         ports:
         - containerPort: 10901
           name: grpc
+        - containerPort: 10902
+          name: http
         volumeMounts:
         - mountPath: /var/thanos/store
           name: data

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -53,10 +53,17 @@ objects:
         - args:
           - query
           - --query.replica-label=replica
+          - --grpc-address=0.0.0.0:10901
+          - --http-address=0.0.0.0:9090
           - --store=dnssrv+_grpc._tcp.thanos-store.${NAMESPACE}.svc.cluster.local
           - --store=dnssrv+_grpc._tcp.thanos-receive.${NAMESPACE}.svc.cluster.local
           image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
           name: thanos-querier
+          ports:
+          - containerPort: 10901
+            name: grpc
+          - containerPort: 9090
+            name: http
         - args:
           - -provider=openshift
           - -https-address=:9091
@@ -298,6 +305,7 @@ objects:
         - args:
           - receive
           - --grpc-address=0.0.0.0:10901
+          - --http-address=0.0.0.0:10902
           - --remote-write.address=0.0.0.0:19291
           - --objstore.config=$(OBJSTORE_CONFIG)
           - --tsdb.path=/var/thanos/tsdb
@@ -392,6 +400,7 @@ objects:
           - store
           - --data-dir=/var/thanos/store
           - --grpc-address=0.0.0.0:10901
+          - --http-address=0.0.0.0:10902
           - --objstore.config=$(OBJSTORE_CONFIG)
           env:
           - name: OBJSTORE_CONFIG
@@ -414,6 +423,8 @@ objects:
           ports:
           - containerPort: 10901
             name: grpc
+          - containerPort: 10902
+            name: http
           volumeMounts:
           - mountPath: /var/thanos/store
             name: data

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/kube-thanos"
                 }
             },
-            "version": "bc0c30a1210e9210b8db4efcb9af7cdf1a10c309"
+            "version": "fc2ec1e9b3e583db5afaaf6f2249761e660ff356"
         },
         {
             "name": "ksonnet",


### PR DESCRIPTION
Add basic CI for PRs (: 

The referenced commit for kube-thanos in the jsonnet lockfile does not
actually exist upstream. It seems there must have been a force push or
something that overwrote it. This bumps the commit and re-generates the
files.

cc @metalmatze 