### PR TITLE
environemnts: fix services for thanos receive

### DIFF
--- a/environments/kubernetes/manifests/thanos-receive-controller-configmap.yaml
+++ b/environments/kubernetes/manifests/thanos-receive-controller-configmap.yaml
@@ -3,7 +3,7 @@ data:
   hashrings.json: |-
     [
       {
-        "hashring": "thanos-receive-default",
+        "hashring": "default",
         "tenants": [
 
         ]

--- a/environments/kubernetes/manifests/thanos-receive-service-default.yaml
+++ b/environments/kubernetes/manifests/thanos-receive-service-default.yaml
@@ -2,8 +2,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app.kubernetes.io/instance: default
     app.kubernetes.io/name: thanos-receive
-  name: thanos-receive
+  name: thanos-receive-default
   namespace: observatorium
 spec:
   clusterIP: None
@@ -18,4 +19,5 @@ spec:
     port: 19291
     targetPort: 19291
   selector:
+    app.kubernetes.io/instance: default
     app.kubernetes.io/name: thanos-receive

--- a/environments/kubernetes/manifests/thanos-receive-statefulSet-default.yaml
+++ b/environments/kubernetes/manifests/thanos-receive-statefulSet-default.yaml
@@ -2,7 +2,8 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
-    app.kubernetes.io/name: thanos-receive-default
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/name: thanos-receive
     controller.receive.thanos.io: thanos-receive-controller
   name: thanos-receive-default
   namespace: observatorium
@@ -10,14 +11,14 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/name: thanos-receive-default
-      controller.receive.thanos.io: thanos-receive-controller
+      app.kubernetes.io/instance: default
+      app.kubernetes.io/name: thanos-receive
   serviceName: thanos-receive
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: thanos-receive-default
-        controller.receive.thanos.io: thanos-receive-controller
+        app.kubernetes.io/instance: default
+        app.kubernetes.io/name: thanos-receive
     spec:
       containers:
       - args:
@@ -31,7 +32,7 @@ spec:
         - --labels=receive="true"
         - --tsdb.retention=6h
         - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
-        - --receive.local-endpoint=http://$(NAME).thanos-receive.$(NAMESPACE).svc.cluster.local:19291/api/v1/receive
+        - --receive.local-endpoint=http://$(NAME).thanos-receive-default.$(NAMESPACE).svc.cluster.local:19291/api/v1/receive
         env:
         - name: NAME
           valueFrom:
@@ -47,7 +48,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         image: improbable/thanos:v0.6.0-rc.0
-        name: thanos-receive-default
+        name: thanos-receive
         ports:
         - containerPort: 10901
           name: grpc

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -111,7 +111,7 @@ objects:
     hashrings.json: |-
       [
         {
-          "hashring": "thanos-receive-default",
+          "hashring": "default",
           "tenants": [
 
           ]
@@ -207,7 +207,7 @@ objects:
   kind: ServiceAccount
   metadata:
     name: thanos-receive-controller
-    namespace: observatorium
+    namespace: ${NAMESPACE}
 - apiVersion: v1
   kind: Service
   metadata:
@@ -228,13 +228,36 @@ objects:
       port: 19291
       targetPort: 19291
     selector:
-      app.kubernetes.io/name: thanos-receive-default
-      controller.receive.thanos.io: thanos-receive-controller
+      app.kubernetes.io/name: thanos-receive
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/instance: default
+      app.kubernetes.io/name: thanos-receive
+    name: thanos-receive-default
+    namespace: ${NAMESPACE}
+  spec:
+    clusterIP: None
+    ports:
+    - name: grpc
+      port: 10901
+      targetPort: 10901
+    - name: http
+      port: 10902
+      targetPort: 10902
+    - name: remote-write
+      port: 19291
+      targetPort: 19291
+    selector:
+      app.kubernetes.io/instance: default
+      app.kubernetes.io/name: thanos-receive
 - apiVersion: apps/v1
   kind: StatefulSet
   metadata:
     labels:
-      app.kubernetes.io/name: thanos-receive-default
+      app.kubernetes.io/instance: default
+      app.kubernetes.io/name: thanos-receive
       controller.receive.thanos.io: thanos-receive-controller
     name: thanos-receive-default
     namespace: ${NAMESPACE}
@@ -242,14 +265,14 @@ objects:
     replicas: ${{THANOS_RECEIVE_REPLICAS}}
     selector:
       matchLabels:
-        app.kubernetes.io/name: thanos-receive-default
-        controller.receive.thanos.io: thanos-receive-controller
+        app.kubernetes.io/instance: default
+        app.kubernetes.io/name: thanos-receive
     serviceName: thanos-receive
     template:
       metadata:
         labels:
-          app.kubernetes.io/name: thanos-receive-default
-          controller.receive.thanos.io: thanos-receive-controller
+          app.kubernetes.io/instance: default
+          app.kubernetes.io/name: thanos-receive
       spec:
         containers:
         - args:
@@ -263,7 +286,7 @@ objects:
           - --labels=receive="true"
           - --tsdb.retention=6h
           - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
-          - --receive.local-endpoint=http://$(NAME).thanos-receive.$(NAMESPACE).svc.cluster.local:19291/api/v1/receive
+          - --receive.local-endpoint=http://$(NAME).thanos-receive-default.$(NAMESPACE).svc.cluster.local:19291/api/v1/receive
           env:
           - name: NAME
             valueFrom:
@@ -289,7 +312,7 @@ objects:
                 key: aws_secret_access_key
                 name: ${THANOS_S3_SECRET}
           image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
-          name: thanos-receive-default
+          name: thanos-receive
           ports:
           - containerPort: 10901
             name: grpc

--- a/tenants.libsonnet
+++ b/tenants.libsonnet
@@ -1,6 +1,7 @@
 [
   {
-    hashring: 'thanos-receive-default',
+    hashring: 'default',
+    replicas:: 3,
     tenants: [
       // Match all for now
       // 'foo',


### PR DESCRIPTION
Previously, only one Thanos receive StatefulSet could be created with
our config. This allows for a StatefulSet and Service to be created
per hashring as well as one Service to select them all and be used by
the querier.

cc @kakkoyun @metalmatze 