### PR TITLE
environments: use labels for hashring names

### DIFF
--- a/components/thanos-receive-controller.libsonnet
+++ b/components/thanos-receive-controller.libsonnet
@@ -77,7 +77,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         local env = container.envType;
 
         local c =
-          container.new($.thanos.receiveController.deployment.metadata.name, 'quay.io/observatorium/thanos-receive-controller:master-2019-07-17-1085ff9') +
+          container.new($.thanos.receiveController.deployment.metadata.name, 'quay.io/observatorium/thanos-receive-controller:master-2019-08-08-61eeaf0') +
           container.withArgs([
             '--configmap-name=%s' % $.thanos.receiveController.configmap.metadata.name,
             '--configmap-generated-name=%s-generated' % $.thanos.receiveController.configmap.metadata.name,

--- a/environments/kubernetes/kube-thanos.libsonnet
+++ b/environments/kubernetes/kube-thanos.libsonnet
@@ -62,7 +62,10 @@ local rolebinding = k.rbac.v1.roleBinding;
         {
           metadata+: {
             name: 'thanos-receive-' + tenant.hashring,
-            labels+: { 'controller.receive.thanos.io': 'thanos-receive-controller' } + $.thanos.receive['service-' + tenant.hashring].metadata.labels,
+            labels+: {
+              'controller.receive.thanos.io': 'thanos-receive-controller',
+              'controller.receive.thanos.io/hashring': tenant.hashring,
+            } + $.thanos.receive['service-' + tenant.hashring].metadata.labels,
           },
           spec+: {
             replicas: tenant.replicas,

--- a/environments/kubernetes/manifests/thanos-receive-controller-deployment.yaml
+++ b/environments/kubernetes/manifests/thanos-receive-controller-deployment.yaml
@@ -26,6 +26,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/observatorium/thanos-receive-controller:master-2019-07-17-1085ff9
+        image: quay.io/observatorium/thanos-receive-controller:master-2019-08-08-61eeaf0
         name: thanos-receive-controller
       serviceAccount: thanos-receive-controller

--- a/environments/kubernetes/manifests/thanos-receive-statefulSet-default.yaml
+++ b/environments/kubernetes/manifests/thanos-receive-statefulSet-default.yaml
@@ -5,6 +5,7 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: thanos-receive
     controller.receive.thanos.io: thanos-receive-controller
+    controller.receive.thanos.io/hashring: default
   name: thanos-receive-default
   namespace: observatorium
 spec:

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -151,7 +151,7 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: quay.io/observatorium/thanos-receive-controller:master-2019-07-17-1085ff9
+          image: quay.io/observatorium/thanos-receive-controller:master-2019-08-08-61eeaf0
           name: thanos-receive-controller
         serviceAccount: thanos-receive-controller
 - apiVersion: rbac.authorization.k8s.io/v1
@@ -259,6 +259,7 @@ objects:
       app.kubernetes.io/instance: default
       app.kubernetes.io/name: thanos-receive
       controller.receive.thanos.io: thanos-receive-controller
+      controller.receive.thanos.io/hashring: default
     name: thanos-receive-default
     namespace: ${NAMESPACE}
   spec:


### PR DESCRIPTION
xref https://github.com/observatorium/thanos-receive-controller/pull/21

note, for this to work, we have to make sure that the configmaps in staging and prod have the right hashring name, i.e. `default` rather than `thanos-receive-default`.