### PR TITLE
environments/sre: doubled thanos-receive metrics

### DIFF
--- a/environments/sre/servicemonitors.jsonnet
+++ b/environments/sre/servicemonitors.jsonnet
@@ -36,7 +36,10 @@ local sm =
           },
           spec+: {
             selector+: {
-              matchLabels: { 'app.kubernetes.io/name': 'thanos-receive' },
+              matchLabels: {
+                'app.kubernetes.io/name': 'thanos-receive',
+                'controller.receive.thanos.io': 'thanos-receive-controller',
+              },
             },
           },
         },

--- a/environments/sre/servicemonitors/observatorium-thanos-receive-production.servicemonitor.yaml
+++ b/environments/sre/servicemonitors/observatorium-thanos-receive-production.servicemonitor.yaml
@@ -13,3 +13,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: thanos-receive
+      controller.receive.thanos.io: thanos-receive-controller

--- a/environments/sre/servicemonitors/observatorium-thanos-receive-stage.servicemonitor.yaml
+++ b/environments/sre/servicemonitors/observatorium-thanos-receive-stage.servicemonitor.yaml
@@ -13,3 +13,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: thanos-receive
+      controller.receive.thanos.io: thanos-receive-controller


### PR DESCRIPTION
Right now, the thanos-receive ServiceMonitor selector selects
both the `thanos-receive` and `thanos-receive-default` services.
This results in doubled metrics.

Both services should exist, but only one or the other should be
selected. Each statefulset also needs its own service and
thanos-receive will select all hash rings (so telemeter can forward
to all with just one service, querier can select all etc).

This PR adds an additional selector to the ServiceMonitor to onle select
the services specific to each statefulset, excluding the overarching
service.

cc @metalmatze @brancz @aditya-konarde @kakkoyun 