### PR TITLE
environments: add service monitor per tenant

### DIFF
--- a/environments/sre/servicemonitors/observatorium-thanos-receive-default-production.servicemonitor.yaml
+++ b/environments/sre/servicemonitors/observatorium-thanos-receive-default-production.servicemonitor.yaml
@@ -3,14 +3,14 @@ kind: ServiceMonitor
 metadata:
   labels:
     prometheus: app-sre
-  name: observatorium-thanos-receive-stage
+  name: observatorium-thanos-receive-default-production
 spec:
   endpoints:
   - port: http
   namespaceSelector:
     matchNames:
-    - telemeter-stage
+    - telemeter-production
   selector:
     matchLabels:
+      app.kubernetes.io/instance: default
       app.kubernetes.io/name: thanos-receive
-      controller.receive.thanos.io: thanos-receive-controller

--- a/environments/sre/servicemonitors/observatorium-thanos-receive-default-stage.servicemonitor.yaml
+++ b/environments/sre/servicemonitors/observatorium-thanos-receive-default-stage.servicemonitor.yaml
@@ -3,14 +3,14 @@ kind: ServiceMonitor
 metadata:
   labels:
     prometheus: app-sre
-  name: observatorium-thanos-receive-production
+  name: observatorium-thanos-receive-default-stage
 spec:
   endpoints:
   - port: http
   namespaceSelector:
     matchNames:
-    - telemeter-production
+    - telemeter-stage
   selector:
     matchLabels:
+      app.kubernetes.io/instance: default
       app.kubernetes.io/name: thanos-receive
-      controller.receive.thanos.io: thanos-receive-controller


### PR DESCRIPTION
Just as we have one service for every thanos-receive hashring, we want
one service monitor for every hashring as well.

cc @metalmatze @kakkoyun 