### PR TITLE
Add missing container port for Thanos Receive controller

### DIFF
--- a/components/thanos-receive-controller.libsonnet
+++ b/components/thanos-receive-controller.libsonnet
@@ -74,6 +74,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       deployment:
         local deployment = k.apps.v1.deployment;
         local container = deployment.mixin.spec.template.spec.containersType;
+        local containerPort = container.portsType;
         local env = container.envType;
 
         local c =
@@ -85,7 +86,9 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
             '--namespace=$(NAMESPACE)',
           ]) + container.withEnv([
             env.fromFieldPath('NAMESPACE', 'metadata.namespace'),
-          ]);
+          ]) + container.withPorts(
+            containerPort.newNamed(8080, 'http')
+          );
 
         deployment.new('thanos-receive-controller', 1, c, $.thanos.receiveController.deployment.metadata.labels) +
         deployment.mixin.metadata.withNamespace('observatorium') +

--- a/environments/kubernetes/manifests/thanos-receive-controller-deployment.yaml
+++ b/environments/kubernetes/manifests/thanos-receive-controller-deployment.yaml
@@ -28,4 +28,7 @@ spec:
               fieldPath: metadata.namespace
         image: quay.io/observatorium/thanos-receive-controller:master-2019-08-09-c8204c0
         name: thanos-receive-controller
+        ports:
+        - containerPort: 8080
+          name: http
       serviceAccount: thanos-receive-controller

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -153,6 +153,9 @@ objects:
                 fieldPath: metadata.namespace
           image: quay.io/observatorium/thanos-receive-controller:master-2019-08-09-c8204c0
           name: thanos-receive-controller
+          ports:
+          - containerPort: 8080
+            name: http
         serviceAccount: thanos-receive-controller
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role


### PR DESCRIPTION
After adding service monitors #44, we haven't able to scrape any metrics so far. I assumed `thanos-receive-controller` deployment has a missin port specification.
This PR attempts to solve the specified problem.

cc @squat @metalmatze 