### PR TITLE
Add auth proxy for cache, change cache container port

### DIFF
--- a/components/thanos-querier-cache.libsonnet
+++ b/components/thanos-querier-cache.libsonnet
@@ -17,7 +17,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
               target: 'query-frontend',
               http_prefix: null,
               server: {
-                http_listen_port: 9091,
+                http_listen_port: 9090,
               },
               frontend: {
                 split_queries_by_day: true,

--- a/components/thanos-querier-cache.libsonnet
+++ b/components/thanos-querier-cache.libsonnet
@@ -47,7 +47,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           'observatorium-cache',
           $.thanos.querierCache.deployment.metadata.labels,
           [
-            ports.newNamed('http', 9091, 9091),
+            ports.newNamed('cache', 9090, 9090),
           ],
         ) +
         service.mixin.metadata.withNamespace('observatorium') +

--- a/environments/kubernetes/manifests/thanos-querier-cache-configmap.yaml
+++ b/environments/kubernetes/manifests/thanos-querier-cache-configmap.yaml
@@ -16,7 +16,7 @@ data:
       "split_queries_by_day": true
     "http_prefix": null
     "server":
-      "http_listen_port": 9091
+      "http_listen_port": 9090
     "target": "query-frontend"
 kind: ConfigMap
 metadata:

--- a/environments/kubernetes/manifests/thanos-querier-cache-service.yaml
+++ b/environments/kubernetes/manifests/thanos-querier-cache-service.yaml
@@ -7,8 +7,8 @@ metadata:
   namespace: observatorium
 spec:
   ports:
-  - name: http
-    port: 9091
-    targetPort: 9091
+  - name: cache
+    port: 9090
+    targetPort: 9090
   selector:
     app.kubernetes.io/name: observatorium-querier-cache

--- a/environments/openshift/kube-thanos.libsonnet
+++ b/environments/openshift/kube-thanos.libsonnet
@@ -272,6 +272,13 @@ local list = import 'telemeter/lib/list.libsonnet';
       roleBinding+: setSubjectNamespace(super.roleBinding) + roleBinding.mixin.metadata.withNamespace(namespace),
     },
     querierCache+: {
+      // The proxy secret is there to encrypt session created by the oauth proxy.
+      proxySecret:
+        secret.new('querier-proxy', {
+          session_secret: std.base64($.thanos.variables.proxyConfig.sessionSecret),
+        }) +
+        secret.mixin.metadata.withNamespace(namespace) +
+        secret.mixin.metadata.withLabels({ 'app.kubernetes.io/name': 'thanos-querier' }),
       configmap+:
         configmap.mixin.metadata.withNamespace(namespace),
       service+:
@@ -294,12 +301,44 @@ local list = import 'telemeter/lib/list.libsonnet';
                       },
                     },
                   },
+                ] + [
+                  container.new('proxy', $.thanos.variables.proxyImage) +
+                  container.withArgs([
+                    '-provider=openshift',
+                    '-https-address=:%d' % $.thanos.querier.service.spec.ports[2].port,
+                    '-http-address=',
+                    '-email-domain=*',
+                    '-upstream=http://localhost:%d' % $.thanos.querier.service.spec.ports[1].port,
+                    '-openshift-service-account=prometheus-telemeter',
+                    '-openshift-sar={"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}", "namespace": "${NAMESPACE}"}',
+                    '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}", "namespace": "${NAMESPACE}"}}',
+                    '-tls-cert=/etc/tls/private/tls.crt',
+                    '-tls-key=/etc/tls/private/tls.key',
+                    '-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token',
+                    '-cookie-secret-file=/etc/proxy/secrets/session_secret',
+                    '-openshift-ca=/etc/pki/tls/cert.pem',
+                    '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
+                    '-skip-auth-regex=^/metrics',
+                  ]) +
+                  container.withPorts([
+                    { name: 'https', containerPort: $.thanos.querier.service.spec.ports[2].port },
+                  ]) +
+                  container.withVolumeMounts(
+                    [
+                      volumeMount.new('secret-querier-cache-tls', '/etc/tls/private'),
+                      volumeMount.new('secret-querier-cache-proxy', '/etc/proxy/secrets'),
+                    ]
+                  ),
                 ],
               },
             },
           },
         } +
-        deployment.mixin.metadata.withNamespace(namespace),
+        deployment.mixin.metadata.withNamespace(namespace) +
+        deployment.mixin.spec.template.spec.withVolumes([
+          volume.fromSecret('secret-querier-cache-tls', 'querier-cache-tls'),
+          volume.fromSecret('secret-querier-cache-proxy', 'querier-cache-proxy'),
+        ]),
     },
   },
 } + {

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -191,21 +191,26 @@ objects:
   metadata:
     labels:
       app.kubernetes.io/name: thanos-querier
-    name: querier-proxy
+    name: querier-cache-proxy
     namespace: ${NAMESPACE}
   type: Opaque
 - apiVersion: v1
   kind: Service
   metadata:
+    annotations:
+      service.alpha.openshift.io/serving-cert-secret-name: querier-tls
     labels:
       app.kubernetes.io/name: observatorium-querier-cache
     name: observatorium-cache
     namespace: ${NAMESPACE}
   spec:
     ports:
-    - name: http
+    - name: cache
+      port: 9090
+      targetPort: 9090
+    - name: proxy
       port: 9091
-      targetPort: 9091
+      targetPort: https
     selector:
       app.kubernetes.io/name: observatorium-querier-cache
 - apiVersion: apps/v1

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -97,7 +97,7 @@ objects:
         "split_queries_by_day": true
       "http_prefix": null
       "server":
-        "http_listen_port": 9091
+        "http_listen_port": 9090
       "target": "query-frontend"
   kind: ConfigMap
   metadata:
@@ -147,10 +147,53 @@ objects:
           - mountPath: /etc/cache-config/
             name: querier-cache-config
             readOnly: false
+        - args:
+          - -provider=openshift
+          - -https-address=:9091
+          - -http-address=
+          - -email-domain=*
+          - -upstream=http://localhost:9090
+          - -openshift-service-account=prometheus-telemeter
+          - '-openshift-sar={"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}",
+            "namespace": "${NAMESPACE}"}'
+          - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get",
+            "name": "${NAMESPACE}", "namespace": "${NAMESPACE}"}}'
+          - -tls-cert=/etc/tls/private/tls.crt
+          - -tls-key=/etc/tls/private/tls.key
+          - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+          - -cookie-secret-file=/etc/proxy/secrets/session_secret
+          - -openshift-ca=/etc/pki/tls/cert.pem
+          - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          - -skip-auth-regex=^/metrics
+          image: ${PROXY_IMAGE}:${PROXY_IMAGE_TAG}
+          name: proxy
+          ports:
+          - containerPort: 9091
+            name: https
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: secret-querier-cache-tls
+            readOnly: false
+          - mountPath: /etc/proxy/secrets
+            name: secret-querier-cache-proxy
+            readOnly: false
         volumes:
-        - configMap:
-            name: observatorium-cache-conf
-          name: querier-cache-config
+        - name: secret-querier-cache-tls
+          secret:
+            secretName: querier-cache-tls
+        - name: secret-querier-cache-proxy
+          secret:
+            secretName: querier-cache-proxy
+- apiVersion: v1
+  data:
+    session_secret: ""
+  kind: Secret
+  metadata:
+    labels:
+      app.kubernetes.io/name: thanos-querier
+    name: querier-proxy
+    namespace: ${NAMESPACE}
+  type: Opaque
 - apiVersion: v1
   kind: Service
   metadata:


### PR DESCRIPTION
Changes: 
- Add an auth proxy container for the cache container
- Change the cache port to `9090` to be consistent with the querier. 

Related: PR for adding a route redirect reference on the SA used for the auth proxy is already created here: https://github.com/openshift/telemeter/pull/233