### PR TITLE
Fix serving cert secret name for querier cache

### DIFF
--- a/environments/openshift/kube-thanos.libsonnet
+++ b/environments/openshift/kube-thanos.libsonnet
@@ -284,7 +284,7 @@ local list = import 'telemeter/lib/list.libsonnet';
       service+:
         service.mixin.metadata.withNamespace(namespace) +
         service.mixin.metadata.withAnnotations({
-          'service.alpha.openshift.io/serving-cert-secret-name': 'querier-tls',
+          'service.alpha.openshift.io/serving-cert-secret-name': 'querier-cache-tls',
         }) + {
           spec+: {
             ports+: [

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -203,7 +203,7 @@ objects:
   kind: Service
   metadata:
     annotations:
-      service.alpha.openshift.io/serving-cert-secret-name: querier-tls
+      service.alpha.openshift.io/serving-cert-secret-name: querier-cache-tls
     labels:
       app.kubernetes.io/name: observatorium-querier-cache
     name: observatorium-cache


### PR DESCRIPTION
Currently conflicts with the querier tls secret and causes an error