### PR TITLE
Use prometheus-telemeter SA for querier-cache Pod

### DIFF
--- a/environments/openshift/kube-thanos.libsonnet
+++ b/environments/openshift/kube-thanos.libsonnet
@@ -347,7 +347,9 @@ local list = import 'telemeter/lib/list.libsonnet';
             },
           },
         } +
-        deployment.mixin.metadata.withNamespace(namespace),
+        deployment.mixin.metadata.withNamespace(namespace) +
+        deployment.mixin.spec.template.spec.withServiceAccount('prometheus-telemeter') +
+        deployment.mixin.spec.template.spec.withServiceAccountName('prometheus-telemeter'),
     },
   },
 } + {

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -179,6 +179,8 @@ objects:
           - mountPath: /etc/proxy/secrets
             name: secret-querier-cache-proxy
             readOnly: false
+        serviceAccount: prometheus-telemeter
+        serviceAccountName: prometheus-telemeter
         volumes:
         - configMap:
             name: observatorium-cache-conf


### PR DESCRIPTION
This is required because the `default` serviceaccount that gets used in the pod doesn't have the necessary permissions to create a `SubjectAccessReview`. SAR's are needed by the auth proxy