### PR TITLE
Added jaeger all in one with badger storage

### DIFF
--- a/components/jaeger-collector.libsonnet
+++ b/components/jaeger-collector.libsonnet
@@ -1,0 +1,71 @@
+local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
+local service = k.core.v1.service;
+
+{
+  jaeger+:: {
+    headlessService:
+      service.new(
+        'jaeger-collector-headless',
+        $.jaeger.deployment.metadata.labels,
+        [
+          service.mixin.spec.portsType.newNamed('grpc', 14250, 14250),
+        ],
+      ) +
+      service.mixin.metadata.withNamespace('observatorium') +
+      service.mixin.metadata.withLabels({ 'app.kubernetes.io/name': $.jaeger.deployment.metadata.name }) +
+      service.mixin.spec.withClusterIp('None'),
+
+    queryService:
+      service.new(
+        'jaeger-query',
+        $.jaeger.deployment.metadata.labels,
+        [
+          service.mixin.spec.portsType.newNamed('query', 16686, 16686),
+        ],
+      ) +
+      service.mixin.metadata.withNamespace('observatorium') +
+      service.mixin.metadata.withLabels({ 'app.kubernetes.io/name': $.jaeger.deployment.metadata.name }),
+
+    volumeClaim:
+      local claim = k.core.v1.persistentVolumeClaim;
+      claim.new() +
+      claim.mixin.metadata.withName('jaeger-store-data') +
+      claim.mixin.metadata.withNamespace('observatorium') +
+      claim.mixin.metadata.withLabels({ 'app.kubernetes.io/name': $.jaeger.deployment.metadata.name }) +
+      claim.mixin.spec.withAccessModes('ReadWriteOnce') +
+      claim.mixin.spec.resources.withRequests({ storage: '50Gi' },) +
+      claim.mixin.spec.withStorageClassName('standard'),
+
+    deployment:
+      local deployment = k.apps.v1.deployment;
+      local container = deployment.mixin.spec.template.spec.containersType;
+      local containerPort = container.portsType;
+      local env = container.envType;
+      local mount = container.volumeMountsType;
+      local volume = k.apps.v1.statefulSet.mixin.spec.template.spec.volumesType;
+
+      local c =
+        container.new($.jaeger.deployment.metadata.name, 'jaegertracing/all-in-one:1.14.0') +
+        container.withArgs([
+          '--badger.directory-key=/var/jaeger/store/keys',
+          '--badger.directory-value=/var/jaeger/store/values',
+          '--badger.ephemeral=false',
+        ],) +
+        container.withEnv([
+          env.new('SPAN_STORAGE_TYPE', 'badger'),
+        ]) + container.withPorts(
+          [
+            containerPort.newNamed(14250, 'grpc'),
+            containerPort.newNamed(14269, 'admin-http'),
+            containerPort.newNamed(16686, 'query'),
+          ],
+        ) +
+        container.withVolumeMounts([mount.new('jaeger-store-data', '/var/jaeger/store')]);
+
+      deployment.new('jaeger-all-in-one', 1, c, $.jaeger.deployment.metadata.labels) +
+      deployment.mixin.metadata.withNamespace('observatorium') +
+      deployment.mixin.metadata.withLabels({ 'app.kubernetes.io/name': $.jaeger.deployment.metadata.name }) +
+      deployment.mixin.spec.selector.withMatchLabels($.jaeger.deployment.metadata.labels) +
+      deployment.mixin.spec.template.spec.withVolumes(volume.fromPersistentVolumeClaim($.jaeger.volumeClaim.metadata.name, $.jaeger.volumeClaim.metadata.name)),
+  },
+}

--- a/environments/kubernetes/jaeger.libsonnet
+++ b/environments/kubernetes/jaeger.libsonnet
@@ -1,0 +1,1 @@
+(import '../../components/jaeger-collector.libsonnet')

--- a/environments/kubernetes/main.jsonnet
+++ b/environments/kubernetes/main.jsonnet
@@ -1,6 +1,7 @@
 local app =
   (import 'kube-thanos.libsonnet') +
-  (import 'telemeter.libsonnet');
+  (import 'telemeter.libsonnet') +
+  (import 'jaeger.libsonnet');
 
 { ['thanos-querier-' + name]: app.thanos.querier[name] for name in std.objectFields(app.thanos.querier) } +
 { ['thanos-receive-' + name]: app.thanos.receive[name] for name in std.objectFields(app.thanos.receive) } +
@@ -8,4 +9,5 @@ local app =
 { ['thanos-store-' + name]: app.thanos.store[name] for name in std.objectFields(app.thanos.store) } +
 { ['thanos-receive-controller-' + name]: app.thanos.receiveController[name] for name in std.objectFields(app.thanos.receiveController) } +
 { ['thanos-querier-cache-' + name]: app.thanos.querierCache[name] for name in std.objectFields(app.thanos.querierCache) } +
-{ ['telemeter-' + name]: app.telemeterServer[name] for name in std.objectFields(app.telemeterServer) }
+{ ['telemeter-' + name]: app.telemeterServer[name] for name in std.objectFields(app.telemeterServer) } +
+{ ['jaeger-' + name]: app.jaeger[name] for name in std.objectFields(app.jaeger) }

--- a/environments/kubernetes/manifests/jaeger-deployment.yaml
+++ b/environments/kubernetes/manifests/jaeger-deployment.yaml
@@ -20,10 +20,17 @@ spec:
         - --badger.directory-key=/var/jaeger/store/keys
         - --badger.directory-value=/var/jaeger/store/values
         - --badger.ephemeral=false
+        - --collector.queue-size=4000
         env:
         - name: SPAN_STORAGE_TYPE
           value: badger
         image: jaegertracing/all-in-one:1.14.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: "14269"
+            scheme: HTTP
         name: jaeger-all-in-one
         ports:
         - containerPort: 14250
@@ -32,6 +39,19 @@ spec:
           name: admin-http
         - containerPort: 16686
           name: query
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: "14269"
+            scheme: HTTP
+        resources:
+          limits:
+            cpu: "4"
+            memory: 2Gi
+          requests:
+            cpu: "1"
+            memory: 256Mi
         volumeMounts:
         - mountPath: /var/jaeger/store
           name: jaeger-store-data

--- a/environments/kubernetes/manifests/jaeger-deployment.yaml
+++ b/environments/kubernetes/manifests/jaeger-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: jaeger-all-in-one
+  name: jaeger-all-in-one
+  namespace: observatorium
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: jaeger-all-in-one
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: jaeger-all-in-one
+    spec:
+      containers:
+      - args:
+        - --badger.directory-key=/var/jaeger/store/keys
+        - --badger.directory-value=/var/jaeger/store/values
+        - --badger.ephemeral=false
+        env:
+        - name: SPAN_STORAGE_TYPE
+          value: badger
+        image: jaegertracing/all-in-one:1.14.0
+        name: jaeger-all-in-one
+        ports:
+        - containerPort: 14250
+          name: grpc
+        - containerPort: 14269
+          name: admin-http
+        - containerPort: 16686
+          name: query
+        volumeMounts:
+        - mountPath: /var/jaeger/store
+          name: jaeger-store-data
+          readOnly: false
+      volumes:
+      - name: jaeger-store-data
+        persistentVolumeClaim:
+          claimName: jaeger-store-data

--- a/environments/kubernetes/manifests/jaeger-headlessService.yaml
+++ b/environments/kubernetes/manifests/jaeger-headlessService.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: jaeger-all-in-one
+  name: jaeger-collector-headless
+  namespace: observatorium
+spec:
+  clusterIP: None
+  ports:
+  - name: grpc
+    port: 14250
+    targetPort: 14250
+  selector:
+    app.kubernetes.io/name: jaeger-all-in-one

--- a/environments/kubernetes/manifests/jaeger-queryService.yaml
+++ b/environments/kubernetes/manifests/jaeger-queryService.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: jaeger-all-in-one
+  name: jaeger-query
+  namespace: observatorium
+spec:
+  ports:
+  - name: query
+    port: 16686
+    targetPort: 16686
+  selector:
+    app.kubernetes.io/name: jaeger-all-in-one

--- a/environments/kubernetes/manifests/jaeger-volumeClaim.yaml
+++ b/environments/kubernetes/manifests/jaeger-volumeClaim.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/name: jaeger-all-in-one
+  name: jaeger-store-data
+  namespace: observatorium
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: standard


### PR DESCRIPTION
This is a first draft to get Jaeger all in one in Observatorium. This brings a simple Jaeger setup using the `all-in-one` strategy and uses the badger storage type.

This does *not* reflect a production installation as the operator would do. Namely, I removed all the ports that might not be necessary by Thanos. I assume that it will use a Jaeger Agent as sidecar, and this sidecar will then use gRPC to talk to the collectors.

The headless service is to enable the gRPC client side load balancing to work. No services with IP are provided, as I don't think Istio (or other types of ingresses) will be necessary, but I can certainly add an IP-service if needed.

I added a `Makefile` and added a couple of lines to the readme, based on my needs as someone trying to understand how it all works. Let me know if those aren't appropriate and I'll revert those changes.

cc @aditya-konarde for the main parts, and cc @burmanm for the badger-specific settings.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>