### PR TITLE
Fix build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,28 +11,33 @@ set -o pipefail
 rm -rf environments/kubernetes/manifests
 mkdir environments/kubernetes/manifests
 
-jsonnet -J vendor -m environments/kubernetes/manifests environments/kubernetes/main.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml; rm -f {}' -- {}
+jsonnet -J vendor -m environments/kubernetes/manifests environments/kubernetes/main.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
+find environments/kubernetes/manifests -type f ! -name '*.yaml' -delete
 
 # Make sure to start with a clean 'manifests' dir
 rm -rf environments/openshift/manifests
 mkdir environments/openshift/manifests
 
 jsonnet -J vendor environments/openshift/main.jsonnet | gojsontoyaml >environments/openshift/manifests/observatorium-template.yaml
+find environments/openshift/manifests -type f ! -name '*.yaml' -delete
 
 # Make sure to start with a clean 'servicemonitors' dir
 rm -rf environments/sre/servicemonitors
 mkdir environments/sre/servicemonitors
 
-jsonnet -J vendor -m environments/sre/servicemonitors environments/sre/servicemonitors.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml; rm -f {}' -- {}
+jsonnet -J vendor -m environments/sre/servicemonitors environments/sre/servicemonitors.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
+find environments/sre/servicemonitors -type f ! -name '*.yaml' -delete
 
 # Make sure to start with a clean 'prometheusrules' dir
 rm -rf environments/sre/prometheusrules
 mkdir environments/sre/prometheusrules
 
-jsonnet -J vendor -m environments/sre/prometheusrules environments/sre/prometheusrules.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml; rm -f {}' -- {}
+jsonnet -J vendor -m environments/sre/prometheusrules environments/sre/prometheusrules.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
+find environments/sre/prometheusrules -type f ! -name '*.yaml' -delete
 
 # Make sure to start with a clean 'grafana' dir
 rm -rf environments/sre/grafana
 mkdir environments/sre/grafana
 
-jsonnet -J vendor -m environments/sre/grafana environments/sre/grafana.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml; rm -f {}' -- {}
+jsonnet -J vendor -m environments/sre/grafana environments/sre/grafana.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
+find environments/sre/grafana -type f ! -name '*.yaml' -delete


### PR DESCRIPTION
The build script does not remove generated interim files on OS X. This PR attempts to fix the build script. 