### PR TITLE
jsonnetfile: bump kube-thanos to fix compactor

### DIFF
--- a/environments/kubernetes/manifests/thanos-compactor-statefulSet.yaml
+++ b/environments/kubernetes/manifests/thanos-compactor-statefulSet.yaml
@@ -61,4 +61,3 @@ spec:
       volumes:
       - emptyDir: {}
         name: thanos-compactor-data
-  volumeClaimTemplates: []

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -90,7 +90,6 @@ objects:
         volumes:
         - emptyDir: {}
           name: thanos-compactor-data
-    volumeClaimTemplates: []
 - apiVersion: v1
   data:
     observatorium-cache-conf.yaml: |-

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/kube-thanos"
                 }
             },
-            "version": "46c5a3dbead8e1d6259e1de4ef757451febcbf06"
+            "version": "3bb1878aaa21d6b13676877f717368c06448e4c3"
         },
         {
             "name": "ksonnet",


### PR DESCRIPTION
This commit bumps the kube-thanos version to include a fix in PR
https://github.com/thanos-io/kube-thanos/pull/48. This PR fixes an issue
where saas-herder is unable to deploy the Thanos compactor due to a
detected skew in the compactor StatefulSet.

cc @kakkoyun @aditya-konarde 