### PR TITLE
Bump Thanos version v0.7.0

### DIFF
--- a/environments/kubernetes/kube-thanos.libsonnet
+++ b/environments/kubernetes/kube-thanos.libsonnet
@@ -18,7 +18,7 @@ local rolebinding = k.rbac.v1.roleBinding;
 {
   thanos+:: {
     variables+:: {
-      image: 'quay.io/thanos/thanos:v0.6.1',
+      image: 'quay.io/thanos/thanos:v0.7.0',
       objectStorageConfig+: {
         name: 'thanos-objectstorage',
         key: 'thanos.yaml',

--- a/environments/kubernetes/manifests/thanos-compactor-statefulSet.yaml
+++ b/environments/kubernetes/manifests/thanos-compactor-statefulSet.yaml
@@ -32,7 +32,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:v0.6.1
+        image: quay.io/thanos/thanos:v0.7.0
         livenessProbe:
           httpGet:
             path: /-/healthy

--- a/environments/kubernetes/manifests/thanos-querier-deployment.yaml
+++ b/environments/kubernetes/manifests/thanos-querier-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - --http-address=0.0.0.0:9090
         - --store=dnssrv+_grpc._tcp.thanos-store.observatorium.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.thanos-receive.observatorium.svc.cluster.local
-        image: quay.io/thanos/thanos:v0.6.1
+        image: quay.io/thanos/thanos:v0.7.0
         livenessProbe:
           httpGet:
             path: /-/healthy

--- a/environments/kubernetes/manifests/thanos-receive-statefulSet-default.yaml
+++ b/environments/kubernetes/manifests/thanos-receive-statefulSet-default.yaml
@@ -48,7 +48,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/thanos/thanos:v0.6.1
+        image: quay.io/thanos/thanos:v0.7.0
         name: thanos-receive
         ports:
         - containerPort: 10901

--- a/environments/kubernetes/manifests/thanos-store-statefulSet.yaml
+++ b/environments/kubernetes/manifests/thanos-store-statefulSet.yaml
@@ -29,7 +29,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:v0.6.1
+        image: quay.io/thanos/thanos:v0.7.0
         name: thanos-store
         ports:
         - containerPort: 10901


### PR DESCRIPTION
I'd like to bump Thanos version to `v0.7.0` for Observatorim to utilize new probes.

cc @brancz @bwplotka 