### PR TITLE
Create environments/openshift/jaeger-template.yaml

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,6 +19,7 @@ rm -rf environments/openshift/manifests
 mkdir environments/openshift/manifests
 
 jsonnet -J vendor environments/openshift/main.jsonnet | gojsontoyaml >environments/openshift/manifests/observatorium-template.yaml
+jsonnet -J vendor environments/openshift/jaeger.jsonnet | gojsontoyaml >environments/openshift/manifests/jaeger-template.yaml
 find environments/openshift/manifests -type f ! -name '*.yaml' -delete
 
 # Make sure to start with a clean 'servicemonitors' dir

--- a/environments/kubernetes/jaeger.libsonnet
+++ b/environments/kubernetes/jaeger.libsonnet
@@ -1,1 +1,6 @@
-(import '../../components/jaeger-collector.libsonnet')
+(import '../../components/jaeger-collector.libsonnet') + {
+  jaeger+:: {
+    namespace:: 'observatorium',
+    image:: 'jaegertracing/all-in-one:1.14.0',
+  },
+}

--- a/environments/openshift/jaeger.jsonnet
+++ b/environments/openshift/jaeger.jsonnet
@@ -10,7 +10,7 @@ local app =
       queryService+: {
         metadata+: {
           annotations+: {
-            'service.alpha.openshift.io/serving-cert-secret-name': 'querier-tls',
+            'service.alpha.openshift.io/serving-cert-secret-name': 'jaeger-tls',
           },
         },
         spec+: {
@@ -46,7 +46,6 @@ local app =
                   '-cookie-secret-file=/etc/proxy/secrets/session_secret',
                   '-openshift-ca=/etc/pki/tls/cert.pem',
                   '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
-                  '-skip-auth-regex=^/metrics',
                 ]) +
                 container.withPorts([
                   { name: 'https', containerPort: $.jaeger.queryService.spec.ports[1].port },
@@ -84,8 +83,8 @@ local app =
   ],
   parameters: [
     { name: 'NAMESPACE', value: 'telemeter' },
-    { name: 'IMAGE', value: 'jaegertracing' },
-    { name: 'IMAGE_TAG', value: 'all-in-one:1.14.0' },
+    { name: 'IMAGE', value: 'jaegertracing/all-in-one' },
+    { name: 'IMAGE_TAG', value: '1.14.0' },
     { name: 'REPLICAS', value: 1 },
     { name: 'PROXY_IMAGE', value: 'openshift/oauth-proxy' },
     { name: 'PROXY_IMAGE_TAG', value: 'v1.1.0' },

--- a/environments/openshift/jaeger.jsonnet
+++ b/environments/openshift/jaeger.jsonnet
@@ -10,7 +10,7 @@ local app =
       queryService+: {
         metadata+: {
           annotations+: {
-            'service.alpha.openshift.io/serving-cert-secret-name': 'jaeger-tls',
+            'service.alpha.openshift.io/serving-cert-secret-name': 'jaeger-query-tls',
           },
         },
         spec+: {
@@ -52,7 +52,7 @@ local app =
                 ]) +
                 container.withVolumeMounts(
                   [
-                    volumeMount.new('secret-jaeger-tls', '/etc/tls/private'),
+                    volumeMount.new('secret-jaeger-query-tls', '/etc/tls/private'),
                     volumeMount.new('secret-jaeger-proxy', '/etc/proxy/secrets'),
                   ]
                 ),
@@ -61,7 +61,7 @@ local app =
               serviceAccount: 'prometheus-telemeter',
               serviceAccountName: 'prometheus-telemeter',
               volumes+: [
-                { name: 'secret-jaeger-tls', secret: { secretName: 'jaeger-tls' } },
+                { name: 'secret-jaeger-query-tls', secret: { secretName: 'jaeger-query-tls' } },
                 { name: 'secret-jaeger-proxy', secret: { secretName: 'jaeger-proxy' } },
               ],
             },

--- a/environments/openshift/jaeger.jsonnet
+++ b/environments/openshift/jaeger.jsonnet
@@ -1,0 +1,26 @@
+local app =
+  (import '../kubernetes/jaeger.libsonnet') + {
+    jaeger+:: {
+      namespace:: '${NAMESPACE}',
+      image:: '${IMAGE}:${IMAGE_TAG}',
+      replicas:: '${{REPLICAS}}',
+    },
+  };
+
+{
+  apiVersion: 'v1',
+  kind: 'Template',
+  metadata: {
+    name: 'jaeger',
+  },
+  objects: [
+    app.jaeger[name]
+    for name in std.objectFields(app.jaeger)
+  ],
+  parameters: [
+    { name: 'NAMESPACE', value: 'telemeter' },
+    { name: 'IMAGE', value: 'jaegertracing' },
+    { name: 'IMAGE_TAG', value: 'all-in-one:1.14.0' },
+    { name: 'REPLICAS', value: 1 },
+  ],
+}

--- a/environments/openshift/jaeger.jsonnet
+++ b/environments/openshift/jaeger.jsonnet
@@ -1,9 +1,74 @@
+local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
+
 local app =
   (import '../kubernetes/jaeger.libsonnet') + {
     jaeger+:: {
       namespace:: '${NAMESPACE}',
       image:: '${IMAGE}:${IMAGE_TAG}',
       replicas:: '${{REPLICAS}}',
+
+      queryService+: {
+        metadata+: {
+          annotations+: {
+            'service.alpha.openshift.io/serving-cert-secret-name': 'querier-tls',
+          },
+        },
+        spec+: {
+          ports+: [
+            { name: 'https', port: 16687, targetPort: 16687 },
+          ],
+        },
+      },
+
+      local deployment = k.apps.v1.deployment,
+      local volume = deployment.mixin.spec.template.spec.volumesType,
+      local container = deployment.mixin.spec.template.spec.containersType,
+      local volumeMount = container.volumeMountsType,
+
+      deployment+: {
+        spec+: {
+          template+: {
+            spec+: {
+              containers+: [
+                container.new('proxy', '${PROXY_IMAGE}:${PROXY_IMAGE_TAG}') +
+                container.withArgs([
+                  '-provider=openshift',
+                  '-https-address=:%d' % $.jaeger.queryService.spec.ports[1].port,
+                  '-http-address=',
+                  '-email-domain=*',
+                  '-upstream=http://localhost:%d' % $.jaeger.queryService.spec.ports[0].port,
+                  '-openshift-service-account=prometheus-telemeter',
+                  '-openshift-sar={"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}", "namespace": "${NAMESPACE}"}',
+                  '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}", "namespace": "${NAMESPACE}"}}',
+                  '-tls-cert=/etc/tls/private/tls.crt',
+                  '-tls-key=/etc/tls/private/tls.key',
+                  '-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token',
+                  '-cookie-secret-file=/etc/proxy/secrets/session_secret',
+                  '-openshift-ca=/etc/pki/tls/cert.pem',
+                  '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
+                  '-skip-auth-regex=^/metrics',
+                ]) +
+                container.withPorts([
+                  { name: 'https', containerPort: $.jaeger.queryService.spec.ports[1].port },
+                ]) +
+                container.withVolumeMounts(
+                  [
+                    volumeMount.new('secret-jaeger-tls', '/etc/tls/private'),
+                    volumeMount.new('secret-jaeger-proxy', '/etc/proxy/secrets'),
+                  ]
+                ),
+              ],
+
+              serviceAccount: 'prometheus-telemeter',
+              serviceAccountName: 'prometheus-telemeter',
+              volumes+: [
+                { name: 'secret-jaeger-tls', secret: { secretName: 'jaeger-tls' } },
+                { name: 'secret-jaeger-proxy', secret: { secretName: 'jaeger-proxy' } },
+              ],
+            },
+          },
+        },
+      },
     },
   };
 
@@ -22,5 +87,7 @@ local app =
     { name: 'IMAGE', value: 'jaegertracing' },
     { name: 'IMAGE_TAG', value: 'all-in-one:1.14.0' },
     { name: 'REPLICAS', value: 1 },
+    { name: 'PROXY_IMAGE', value: 'openshift/oauth-proxy' },
+    { name: 'PROXY_IMAGE_TAG', value: 'v1.1.0' },
   ],
 }

--- a/environments/openshift/manifests/jaeger-template.yaml
+++ b/environments/openshift/manifests/jaeger-template.yaml
@@ -1,0 +1,119 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: jaeger
+objects:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app.kubernetes.io/name: jaeger-all-in-one
+    name: jaeger-all-in-one
+    namespace: ${NAMESPACE}
+  spec:
+    replicas: ${{REPLICAS}}
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: jaeger-all-in-one
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: jaeger-all-in-one
+      spec:
+        containers:
+        - args:
+          - --badger.directory-key=/var/jaeger/store/keys
+          - --badger.directory-value=/var/jaeger/store/values
+          - --badger.ephemeral=false
+          - --collector.queue-size=4000
+          env:
+          - name: SPAN_STORAGE_TYPE
+            value: badger
+          image: ${IMAGE}:${IMAGE_TAG}
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: "14269"
+              scheme: HTTP
+          name: jaeger-all-in-one
+          ports:
+          - containerPort: 14250
+            name: grpc
+          - containerPort: 14269
+            name: admin-http
+          - containerPort: 16686
+            name: query
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: "14269"
+              scheme: HTTP
+          resources:
+            limits:
+              cpu: "4"
+              memory: 2Gi
+            requests:
+              cpu: "1"
+              memory: 256Mi
+          volumeMounts:
+          - mountPath: /var/jaeger/store
+            name: jaeger-store-data
+            readOnly: false
+        volumes:
+        - name: jaeger-store-data
+          persistentVolumeClaim:
+            claimName: jaeger-store-data
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/name: jaeger-all-in-one
+    name: jaeger-collector-headless
+    namespace: ${NAMESPACE}
+  spec:
+    clusterIP: None
+    ports:
+    - name: grpc
+      port: 14250
+      targetPort: 14250
+    selector:
+      app.kubernetes.io/name: jaeger-all-in-one
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/name: jaeger-all-in-one
+    name: jaeger-query
+    namespace: ${NAMESPACE}
+  spec:
+    ports:
+    - name: query
+      port: 16686
+      targetPort: 16686
+    selector:
+      app.kubernetes.io/name: jaeger-all-in-one
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    labels:
+      app.kubernetes.io/name: jaeger-all-in-one
+    name: jaeger-store-data
+    namespace: ${NAMESPACE}
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 50Gi
+    storageClassName: standard
+parameters:
+- name: NAMESPACE
+  value: telemeter
+- name: IMAGE
+  value: jaegertracing
+- name: IMAGE_TAG
+  value: all-in-one:1.14.0
+- name: REPLICAS
+  value: 1

--- a/environments/openshift/manifests/jaeger-template.yaml
+++ b/environments/openshift/manifests/jaeger-template.yaml
@@ -154,9 +154,9 @@ parameters:
 - name: NAMESPACE
   value: telemeter
 - name: IMAGE
-  value: jaegertracing
+  value: jaegertracing/all-in-one
 - name: IMAGE_TAG
-  value: all-in-one:1.14.0
+  value: 1.14.0
 - name: REPLICAS
   value: 1
 - name: PROXY_IMAGE

--- a/environments/openshift/manifests/jaeger-template.yaml
+++ b/environments/openshift/manifests/jaeger-template.yaml
@@ -78,7 +78,6 @@ objects:
           - -cookie-secret-file=/etc/proxy/secrets/session_secret
           - -openshift-ca=/etc/pki/tls/cert.pem
           - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          - -skip-auth-regex=^/metrics
           image: ${PROXY_IMAGE}:${PROXY_IMAGE_TAG}
           name: proxy
           ports:
@@ -122,7 +121,7 @@ objects:
   kind: Service
   metadata:
     annotations:
-      service.alpha.openshift.io/serving-cert-secret-name: querier-tls
+      service.alpha.openshift.io/serving-cert-secret-name: jaeger-tls
     labels:
       app.kubernetes.io/name: jaeger-all-in-one
     name: jaeger-query

--- a/environments/openshift/manifests/jaeger-template.yaml
+++ b/environments/openshift/manifests/jaeger-template.yaml
@@ -85,7 +85,7 @@ objects:
             name: https
           volumeMounts:
           - mountPath: /etc/tls/private
-            name: secret-jaeger-tls
+            name: secret-jaeger-query-tls
             readOnly: false
           - mountPath: /etc/proxy/secrets
             name: secret-jaeger-proxy
@@ -96,9 +96,9 @@ objects:
         - name: jaeger-store-data
           persistentVolumeClaim:
             claimName: jaeger-store-data
-        - name: secret-jaeger-tls
+        - name: secret-jaeger-query-tls
           secret:
-            secretName: jaeger-tls
+            secretName: jaeger-query-tls
         - name: secret-jaeger-proxy
           secret:
             secretName: jaeger-proxy
@@ -121,7 +121,7 @@ objects:
   kind: Service
   metadata:
     annotations:
-      service.alpha.openshift.io/serving-cert-secret-name: jaeger-tls
+      service.alpha.openshift.io/serving-cert-secret-name: jaeger-query-tls
     labels:
       app.kubernetes.io/name: jaeger-all-in-one
     name: jaeger-query

--- a/environments/openshift/manifests/jaeger-template.yaml
+++ b/environments/openshift/manifests/jaeger-template.yaml
@@ -61,10 +61,48 @@ objects:
           - mountPath: /var/jaeger/store
             name: jaeger-store-data
             readOnly: false
+        - args:
+          - -provider=openshift
+          - -https-address=:16687
+          - -http-address=
+          - -email-domain=*
+          - -upstream=http://localhost:16686
+          - -openshift-service-account=prometheus-telemeter
+          - '-openshift-sar={"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}",
+            "namespace": "${NAMESPACE}"}'
+          - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get",
+            "name": "${NAMESPACE}", "namespace": "${NAMESPACE}"}}'
+          - -tls-cert=/etc/tls/private/tls.crt
+          - -tls-key=/etc/tls/private/tls.key
+          - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+          - -cookie-secret-file=/etc/proxy/secrets/session_secret
+          - -openshift-ca=/etc/pki/tls/cert.pem
+          - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          - -skip-auth-regex=^/metrics
+          image: ${PROXY_IMAGE}:${PROXY_IMAGE_TAG}
+          name: proxy
+          ports:
+          - containerPort: 16687
+            name: https
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: secret-jaeger-tls
+            readOnly: false
+          - mountPath: /etc/proxy/secrets
+            name: secret-jaeger-proxy
+            readOnly: false
+        serviceAccount: prometheus-telemeter
+        serviceAccountName: prometheus-telemeter
         volumes:
         - name: jaeger-store-data
           persistentVolumeClaim:
             claimName: jaeger-store-data
+        - name: secret-jaeger-tls
+          secret:
+            secretName: jaeger-tls
+        - name: secret-jaeger-proxy
+          secret:
+            secretName: jaeger-proxy
 - apiVersion: v1
   kind: Service
   metadata:
@@ -83,6 +121,8 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
+    annotations:
+      service.alpha.openshift.io/serving-cert-secret-name: querier-tls
     labels:
       app.kubernetes.io/name: jaeger-all-in-one
     name: jaeger-query
@@ -92,6 +132,9 @@ objects:
     - name: query
       port: 16686
       targetPort: 16686
+    - name: https
+      port: 16687
+      targetPort: 16687
     selector:
       app.kubernetes.io/name: jaeger-all-in-one
 - apiVersion: v1
@@ -117,3 +160,7 @@ parameters:
   value: all-in-one:1.14.0
 - name: REPLICAS
   value: 1
+- name: PROXY_IMAGE
+  value: openshift/oauth-proxy
+- name: PROXY_IMAGE_TAG
+  value: v1.1.0


### PR DESCRIPTION
Generate the OpenShift template for Jaeger in Observatorium.

I've update the jaeger-collector.libsonnet to introduce the style of passing arguments like kube-state-metrics does now, this also simplifies our templating for OpenShift.

/cc @jpkrohling @bwplotka @brancz @kakkoyun @squat 