### PR TITLE
environments/openshift: bump TRC tag

### DIFF
--- a/environments/openshift/kube-thanos.libsonnet
+++ b/environments/openshift/kube-thanos.libsonnet
@@ -422,7 +422,7 @@ local list = import 'telemeter/lib/list.libsonnet';
         },
         {
           name: 'THANOS_RECEIVE_CONTROLLER_IMAGE_TAG',
-          value: 'master-2019-10-09-6ed4a64',
+          value: 'master-2019-10-18-d55fee2',
         },
         {
           name: 'THANOS_QUERIER_REPLICAS',

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -1097,7 +1097,7 @@ parameters:
 - name: THANOS_RECEIVE_CONTROLLER_IMAGE
   value: quay.io/observatorium/thanos-receive-controller
 - name: THANOS_RECEIVE_CONTROLLER_IMAGE_TAG
-  value: master-2019-10-09-6ed4a64
+  value: master-2019-10-18-d55fee2
 - name: THANOS_QUERIER_REPLICAS
   value: "3"
 - name: THANOS_STORE_REPLICAS


### PR DESCRIPTION
This commit bumps the image tag for the thanos-receive-controller to
include the fix from
https://github.com/observatorium/thanos-receive-controller/pull/33.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @kakkoyun @aditya-konarde 