### PR TITLE
*: Add in-cluster prometheus_replica label for dedup.

### DIFF
--- a/environments/kubernetes/kube-thanos.libsonnet
+++ b/environments/kubernetes/kube-thanos.libsonnet
@@ -41,6 +41,7 @@ local jaegerAgent = import '../../components/jaeger-agent.libsonnet';
                 { args: [
                   'query',
                   '--query.replica-label=replica',
+                  '--query.replica-label=prometheus_replica',
                   '--grpc-address=0.0.0.0:%d' % $.thanos.querier.service.spec.ports[0].port,
                   '--http-address=0.0.0.0:%d' % $.thanos.querier.service.spec.ports[1].port,
                   '--store=dnssrv+_grpc._tcp.%s.%s.svc.cluster.local' % [

--- a/environments/kubernetes/manifests/thanos-querier-deployment.yaml
+++ b/environments/kubernetes/manifests/thanos-querier-deployment.yaml
@@ -19,6 +19,7 @@ spec:
       - args:
         - query
         - --query.replica-label=replica
+        - --query.replica-label=prometheus_replica
         - --grpc-address=0.0.0.0:10901
         - --http-address=0.0.0.0:9090
         - --store=dnssrv+_grpc._tcp.thanos-store.observatorium.svc.cluster.local

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -272,6 +272,7 @@ objects:
         - args:
           - query
           - --query.replica-label=replica
+          - --query.replica-label=prometheus_replica
           - --grpc-address=0.0.0.0:10901
           - --http-address=0.0.0.0:9090
           - --store=dnssrv+_grpc._tcp.thanos-store.${NAMESPACE}.svc.cluster.local


### PR DESCRIPTION
While this could be done at runtime as well as a query parameter, this will for now give us the correct result when querying. Note this will only really have an effect once in-cluster switches to remote write.

@metalmatze @squat @bwplotka @kakkoyun 