### PR TITLE
Add network_attachment_definition for multus changes

### DIFF
--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -965,6 +965,8 @@ objects:
           - --whitelist={__name__="noobaa_accounts_num"}
           - --whitelist={__name__="noobaa_total_usage"}
           - --whitelist={__name__="console_url"}
+          - --whitelist={__name__="cluster:network_attachment_definition_instances:max"}
+          - --whitelist={__name__="cluster:network_attachment_definition_enabled_instance_up:max"}
           - --elide-label=prometheus_replica
           - --token-expire-seconds=3600
           - --forward-url=${TELEMETER_FORWARD_URL}

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -74,8 +74,8 @@
           "subdir": "jsonnet/telemeter"
         }
       },
-      "version": "5495d7cb1082f128defd31244e457b12090c2977",
-      "sum": "Ao7joayZ6ZSaomPR5uMD/A3yQAOuDW1bH3weCiNUYcM="
+      "version": "222b33211c33741eea28eab97a1d404471f51c2a",
+      "sum": "pSymfFux14XHUbc7Yxw0oAfQw1bth3XaTUrmjXUAazA="
     },
     {
       "name": "thanos-mixin",


### PR DESCRIPTION
whitelist metrics and update  temeter version  for following metrics   cluster:network_attachment_definition_instances:max cluster:network_attachment_definition_enabled_instance_up:max
Continuation from
1. https://github.com/openshift/telemeter/pull/262 
2. https://github.com/openshift/cluster-monitoring-operator/pull/537
