### PR TITLE
Add resource requests and limits to containers without

### DIFF
--- a/components/jaeger-agent.libsonnet
+++ b/components/jaeger-agent.libsonnet
@@ -15,6 +15,8 @@ local containerEnv = container.envType;
       containerEnv.fromFieldPath('NAMESPACE', 'metadata.namespace'),
       containerEnv.fromFieldPath('POD', 'metadata.name'),
     ]) +
+    container.mixin.resources.withRequests({ cpu: '32m', memory: '16Mi' }) +
+    container.mixin.resources.withLimits({ cpu: '128m', memory: '64Mi' }) +
     container.withPorts([
       container.portsType.newNamed(6831, 'jaeger-thrift'),
       container.portsType.newNamed(5778, 'configs'),

--- a/environments/kubernetes/manifests/thanos-compactor-statefulSet.yaml
+++ b/environments/kubernetes/manifests/thanos-compactor-statefulSet.yaml
@@ -81,6 +81,13 @@ spec:
           name: jaeger-thrift
         - containerPort: 5778
           name: configs
+        resources:
+          limits:
+            cpu: 128m
+            memory: 64Mi
+          requests:
+            cpu: 32m
+            memory: 16Mi
       volumes:
       - emptyDir: {}
         name: thanos-compactor-data

--- a/environments/kubernetes/manifests/thanos-querier-deployment.yaml
+++ b/environments/kubernetes/manifests/thanos-querier-deployment.yaml
@@ -70,3 +70,10 @@ spec:
           name: jaeger-thrift
         - containerPort: 5778
           name: configs
+        resources:
+          limits:
+            cpu: 128m
+            memory: 64Mi
+          requests:
+            cpu: 32m
+            memory: 16Mi

--- a/environments/kubernetes/manifests/thanos-receive-controller-deployment.yaml
+++ b/environments/kubernetes/manifests/thanos-receive-controller-deployment.yaml
@@ -31,4 +31,11 @@ spec:
         ports:
         - containerPort: 8080
           name: http
+        resources:
+          limits:
+            cpu: 64m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 24Mi
       serviceAccount: thanos-receive-controller

--- a/environments/kubernetes/manifests/thanos-receive-statefulSet-default.yaml
+++ b/environments/kubernetes/manifests/thanos-receive-statefulSet-default.yaml
@@ -102,6 +102,13 @@ spec:
           name: jaeger-thrift
         - containerPort: 5778
           name: configs
+        resources:
+          limits:
+            cpu: 128m
+            memory: 64Mi
+          requests:
+            cpu: 32m
+            memory: 16Mi
       volumes:
       - configMap:
           name: observatorium-tenants-generated

--- a/environments/kubernetes/manifests/thanos-store-statefulSet.yaml
+++ b/environments/kubernetes/manifests/thanos-store-statefulSet.yaml
@@ -79,6 +79,13 @@ spec:
           name: jaeger-thrift
         - containerPort: 5778
           name: configs
+        resources:
+          limits:
+            cpu: 128m
+            memory: 64Mi
+          requests:
+            cpu: 32m
+            memory: 16Mi
       volumes: null
   volumeClaimTemplates:
   - metadata:

--- a/environments/openshift/kube-thanos.libsonnet
+++ b/environments/openshift/kube-thanos.libsonnet
@@ -355,6 +355,8 @@ local list = import 'telemeter/lib/list.libsonnet';
                   container.withPorts([
                     { name: 'https', containerPort: $.thanos.querier.service.spec.ports[2].port },
                   ]) +
+                  container.mixin.resources.withRequests({ cpu: '32m', memory: '32Mi' }) +
+                  container.mixin.resources.withLimits({ cpu: '64m', memory: '128Mi' }) +
                   container.withVolumeMounts(
                     [
                       volumeMount.new('secret-querier-cache-tls', '/etc/tls/private'),

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -466,6 +466,13 @@ objects:
           ports:
           - containerPort: 8080
             name: http
+          resources:
+            limits:
+              cpu: 64m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 24Mi
         serviceAccount: thanos-receive-controller
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -110,6 +110,13 @@ objects:
             name: jaeger-thrift
           - containerPort: 5778
             name: configs
+          resources:
+            limits:
+              cpu: 128m
+              memory: 64Mi
+            requests:
+              cpu: 32m
+              memory: 16Mi
         volumes:
         - emptyDir: {}
           name: thanos-compactor-data
@@ -204,6 +211,13 @@ objects:
           ports:
           - containerPort: 9091
             name: https
+          resources:
+            limits:
+              cpu: 64m
+              memory: 128Mi
+            requests:
+              cpu: 32m
+              memory: 32Mi
           volumeMounts:
           - mountPath: /etc/tls/private
             name: secret-querier-cache-tls
@@ -324,6 +338,13 @@ objects:
             name: jaeger-thrift
           - containerPort: 5778
             name: configs
+          resources:
+            limits:
+              cpu: 128m
+              memory: 64Mi
+            requests:
+              cpu: 32m
+              memory: 16Mi
         - args:
           - -provider=openshift
           - -https-address=:9091
@@ -670,6 +691,13 @@ objects:
             name: jaeger-thrift
           - containerPort: 5778
             name: configs
+          resources:
+            limits:
+              cpu: 128m
+              memory: 64Mi
+            requests:
+              cpu: 32m
+              memory: 16Mi
         volumes:
         - configMap:
             name: observatorium-tenants-generated
@@ -793,6 +821,13 @@ objects:
             name: jaeger-thrift
           - containerPort: 5778
             name: configs
+          resources:
+            limits:
+              cpu: 128m
+              memory: 64Mi
+            requests:
+              cpu: 32m
+              memory: 16Mi
         volumes: null
     volumeClaimTemplates:
     - metadata:
@@ -1097,6 +1132,13 @@ objects:
           ports:
           - containerPort: 8080
             name: http
+          resources:
+            limits:
+              cpu: 100m
+              memory: 64Mi
+            requests:
+              cpu: 50m
+              memory: 16Mi
           volumeMounts:
           - mountPath: /config
             name: prometheus-remote-write-proxy-config

--- a/environments/openshift/prometheus.libsonnet
+++ b/environments/openshift/prometheus.libsonnet
@@ -193,6 +193,8 @@ local list = import 'telemeter/lib/list.libsonnet';
           '/config/nginx.conf',
         ]) +
         container.withPorts([{ name: 'http', containerPort: $._config.ams.proxyPort }]) +
+        container.mixin.resources.withRequests({ cpu: '50m', memory: '16Mi' }) +
+        container.mixin.resources.withLimits({ cpu: '100m', memory: '64Mi' }) +
         container.withVolumeMounts([volumeMount.new($.prometheusRemoteWriteProxy.configmap.metadata.name, '/config', true)]);
 
       deployment.new('prometheus-remote-write-proxy', 1, c, selectorLabels) +

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -96,8 +96,8 @@
           "subdir": "jsonnet/lib"
         }
       },
-      "version": "965e79d6f5679ccd42053151ca84dbf815ff0012",
-      "sum": "vJAU/C1iuD1HS0v4ylubg9+LlwdRVuYu5/bO9MVC7gY="
+      "version": "47c08cc6789327b9124bceccea346a3759041cb2",
+      "sum": "EGr26vVxp0ZKDHd3EGBlsozeOa3/9sRF+L/qAMZmpw4="
     },
     {
       "name": "thanos-receive-controller-mixin",


### PR DESCRIPTION
Add missing resource requests and limits for containers that don't have that.

One final one is missing, but that's not defined in this repo, but rather a dependency. For that I've created: https://github.com/observatorium/thanos-receive-controller/pull/35