### PR TITLE
environment/kubernetes: replicate received data

### DIFF
--- a/environments/kubernetes/kube-thanos.libsonnet
+++ b/environments/kubernetes/kube-thanos.libsonnet
@@ -176,7 +176,7 @@ local jaegerAgent = import '../../components/jaeger-agent.libsonnet';
                         $.thanos.receive['service-' + tenant.hashring].spec.ports[2].port,
                       ],
                       jaegerAgent.thanosFlag % $.thanos.receive['statefulSet-' + tenant.hashring].metadata.name,
-                    ],
+                    ] + (if tenant.replicas >= 3 then ['--receive.replication-factor=3']),
                     volumeMounts+: [
                       { name: 'observatorium-tenants', mountPath: '/var/lib/thanos-receive' },
                     ],

--- a/environments/kubernetes/manifests/thanos-receive-statefulSet-default.yaml
+++ b/environments/kubernetes/manifests/thanos-receive-statefulSet-default.yaml
@@ -42,6 +42,7 @@ spec:
               service_name: thanos-receive-default
               sampler_type: ratelimiting
               sampler_param: 2
+        - --receive.replication-factor=3
         env:
         - name: NAME
           valueFrom:

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -653,6 +653,7 @@ objects:
                 service_name: thanos-receive-default
                 sampler_type: ratelimiting
                 sampler_param: 2
+          - --receive.replication-factor=3
           env:
           - name: NAME
             valueFrom:

--- a/environments/openshift/manifests/thanos-template.yaml
+++ b/environments/openshift/manifests/thanos-template.yaml
@@ -672,6 +672,7 @@ objects:
                   service_name: thanos-receive-default
                   sampler_type: ratelimiting
                   sampler_param: 2
+            - --receive.replication-factor=3
             env:
             - name: NAME
               valueFrom:


### PR DESCRIPTION
This commit enables replication of all received data. It ensures that
all hashrings with more than 3 replicas will have a replication factor
of 3.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @kakkoyun @metalmatze @aditya-konarde 
We need to discuss if increased CPU + disk usage to handle replication
will be provisioned.