### PR TITLE
Fix Jaeger component monitoring issues

### DIFF
--- a/components/jaeger-agent.libsonnet
+++ b/components/jaeger-agent.libsonnet
@@ -17,10 +17,15 @@ local containerEnv = container.envType;
     ]) +
     container.mixin.resources.withRequests({ cpu: '32m', memory: '16Mi' }) +
     container.mixin.resources.withLimits({ cpu: '128m', memory: '64Mi' }) +
+    container.mixin.livenessProbe.withFailureThreshold(5) +
+    container.mixin.livenessProbe.httpGet.withPath('/').withPort(self.metricsPort).withScheme('HTTP') +
     container.withPorts([
       container.portsType.newNamed(6831, 'jaeger-thrift'),
       container.portsType.newNamed(5778, 'configs'),
+      container.portsType.newNamed(self.metricsPort, 'metrics'),
     ]),
+
+  metricsPort:: 14271,
 
   thanosFlag:: |||
     --tracing.config=
@@ -30,4 +35,8 @@ local containerEnv = container.envType;
         sampler_type: ratelimiting
         sampler_param: 2
   |||,
+
+  labels:: {
+    'app.kubernetes.io/tracing': 'jaeger-agent',
+  },
 }

--- a/components/jaeger-agent.libsonnet
+++ b/components/jaeger-agent.libsonnet
@@ -26,7 +26,12 @@ local containerEnv = container.envType;
     ]),
 
   metricsPort:: 14271,
-
+  serviceLabels:: {
+    'app.kubernetes.io/name': 'jaeger-agent',
+  },
+  labels:: {
+    'app.kubernetes.io/tracing': 'jaeger-agent',
+  },
   thanosFlag:: |||
     --tracing.config=
       type: JAEGER
@@ -35,8 +40,4 @@ local containerEnv = container.envType;
         sampler_type: ratelimiting
         sampler_param: 2
   |||,
-
-  labels:: {
-    'app.kubernetes.io/tracing': 'jaeger-agent',
-  },
 }

--- a/components/jaeger-collector.libsonnet
+++ b/components/jaeger-collector.libsonnet
@@ -35,6 +35,17 @@ local service = k.core.v1.service;
       service.mixin.metadata.withNamespace(j.namespace) +
       service.mixin.metadata.withLabels({ 'app.kubernetes.io/name': $.jaeger.deployment.metadata.name }),
 
+    adminService:
+      service.new(
+        'jaeger-admin',
+        $.jaeger.deployment.metadata.labels,
+        [
+          service.mixin.spec.portsType.newNamed('admin-http', 14269, 14269),
+        ],
+      ) +
+      service.mixin.metadata.withNamespace(j.namespace) +
+      service.mixin.metadata.withLabels({ 'app.kubernetes.io/name': $.jaeger.deployment.metadata.name }),
+
     volumeClaim:
       local claim = k.core.v1.persistentVolumeClaim;
       claim.new() +

--- a/components/jaeger-collector.libsonnet
+++ b/components/jaeger-collector.libsonnet
@@ -86,8 +86,11 @@ local service = k.core.v1.service;
         ) +
         container.withVolumeMounts([mount.new('jaeger-store-data', '/var/jaeger/store')]) +
         container.mixin.readinessProbe.withFailureThreshold(3) +
+        container.mixin.readinessProbe.withPeriodSeconds(30) +
+        container.mixin.readinessProbe.withInitialDelaySeconds(30) +
         container.mixin.readinessProbe.httpGet.withPath('/').withPort(14269).withScheme('HTTP') +
-        container.mixin.livenessProbe.withFailureThreshold(3) +
+        container.mixin.livenessProbe.withPeriodSeconds(30) +
+        container.mixin.livenessProbe.withFailureThreshold(4) +
         container.mixin.livenessProbe.httpGet.withPath('/').withPort(14269).withScheme('HTTP') +
         container.mixin.resources.withRequests({ cpu: '1', memory: '256Mi' }) +
         container.mixin.resources.withLimits({ cpu: '4', memory: '2Gi' });

--- a/components/jaeger-collector.libsonnet
+++ b/components/jaeger-collector.libsonnet
@@ -99,7 +99,7 @@ local jaegerAgent = import './jaeger-agent.libsonnet';
         container.withVolumeMounts([mount.new('jaeger-store-data', '/var/jaeger/store')]) +
         container.mixin.readinessProbe.withFailureThreshold(3) +
         container.mixin.readinessProbe.withPeriodSeconds(30) +
-        container.mixin.readinessProbe.withInitialDelaySeconds(30) +
+        container.mixin.readinessProbe.withInitialDelaySeconds(10) +
         container.mixin.readinessProbe.httpGet.withPath('/').withPort(14269).withScheme('HTTP') +
         container.mixin.livenessProbe.withPeriodSeconds(30) +
         container.mixin.livenessProbe.withFailureThreshold(4) +

--- a/components/jaeger-collector.libsonnet
+++ b/components/jaeger-collector.libsonnet
@@ -1,5 +1,6 @@
 local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
 local service = k.core.v1.service;
+local jaegerAgent = import './jaeger-agent.libsonnet';
 
 {
   jaeger+:: {
@@ -45,6 +46,17 @@ local service = k.core.v1.service;
       ) +
       service.mixin.metadata.withNamespace(j.namespace) +
       service.mixin.metadata.withLabels({ 'app.kubernetes.io/name': $.jaeger.deployment.metadata.name }),
+
+    agentService:
+      service.new(
+        'jaeger-agent',
+        jaegerAgent.labels,
+        [
+          service.mixin.spec.portsType.newNamed('metrics', jaegerAgent.metricsPort, jaegerAgent.metricsPort),
+        ],
+      ) +
+      service.mixin.metadata.withNamespace(j.namespace) +
+      service.mixin.metadata.withLabels(jaegerAgent.serviceLabels),
 
     volumeClaim:
       local claim = k.core.v1.persistentVolumeClaim;

--- a/environments/kubernetes/kube-thanos.libsonnet
+++ b/environments/kubernetes/kube-thanos.libsonnet
@@ -36,6 +36,9 @@ local jaegerAgent = import '../../components/jaeger-agent.libsonnet';
       deployment+: {
         spec+: {
           template+: {
+            metadata+: {
+              labels+: super.labels + jaegerAgent.labels,
+            },
             spec+: {
               containers: [
                 super.containers[0]
@@ -71,6 +74,9 @@ local jaegerAgent = import '../../components/jaeger-agent.libsonnet';
       statefulSet+: {
         spec+: {
           template+: {
+            metadata+: {
+              labels+: super.labels + jaegerAgent.labels,
+            },
             spec+: {
               containers: [
                 super.containers[0]
@@ -89,6 +95,9 @@ local jaegerAgent = import '../../components/jaeger-agent.libsonnet';
       statefulSet+: {
         spec+: {
           template+: {
+            metadata+: {
+              labels+: super.labels + jaegerAgent.labels,
+            },
             spec+: {
               containers: [
                 super.containers[0] {
@@ -140,10 +149,12 @@ local jaegerAgent = import '../../components/jaeger-agent.libsonnet';
         {
           metadata+: {
             name: 'thanos-receive-' + tenant.hashring,
-            labels+: {
-              'controller.receive.thanos.io': 'thanos-receive-controller',
-              'controller.receive.thanos.io/hashring': tenant.hashring,
-            } + $.thanos.receive['service-' + tenant.hashring].metadata.labels,
+            labels+:
+              {
+                'controller.receive.thanos.io': 'thanos-receive-controller',
+                'controller.receive.thanos.io/hashring': tenant.hashring,
+              } + $.thanos.receive['service-' + tenant.hashring].metadata.labels
+              + jaegerAgent.labels,
           },
           spec+: {
             replicas: tenant.replicas,

--- a/environments/kubernetes/manifests/jaeger-adminService.yaml
+++ b/environments/kubernetes/manifests/jaeger-adminService.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: jaeger-all-in-one
+  name: jaeger-admin
+  namespace: observatorium
+spec:
+  ports:
+  - name: admin-http
+    port: 14269
+    targetPort: 14269
+  selector:
+    app.kubernetes.io/name: jaeger-all-in-one

--- a/environments/kubernetes/manifests/jaeger-agentService.yaml
+++ b/environments/kubernetes/manifests/jaeger-agentService.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: jaeger-agent
+  name: jaeger-agent
+  namespace: observatorium
+spec:
+  ports:
+  - name: metrics
+    port: 14271
+    targetPort: 14271
+  selector:
+    app.kubernetes.io/tracing: jaeger-agent

--- a/environments/kubernetes/manifests/jaeger-deployment.yaml
+++ b/environments/kubernetes/manifests/jaeger-deployment.yaml
@@ -30,11 +30,12 @@ spec:
           value: badger
         image: jaegertracing/all-in-one:1.14.0
         livenessProbe:
-          failureThreshold: 3
+          failureThreshold: 4
           httpGet:
             path: /
             port: 14269
             scheme: HTTP
+          periodSeconds: 30
         name: jaeger-all-in-one
         ports:
         - containerPort: 14250
@@ -49,6 +50,8 @@ spec:
             path: /
             port: 14269
             scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 30
         resources:
           limits:
             cpu: "4"

--- a/environments/kubernetes/manifests/jaeger-deployment.yaml
+++ b/environments/kubernetes/manifests/jaeger-deployment.yaml
@@ -50,7 +50,7 @@ spec:
             path: /
             port: 14269
             scheme: HTTP
-          initialDelaySeconds: 30
+          initialDelaySeconds: 10
           periodSeconds: 30
         resources:
           limits:

--- a/environments/kubernetes/manifests/thanos-compactor-statefulSet.yaml
+++ b/environments/kubernetes/manifests/thanos-compactor-statefulSet.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: thanos-compactor
+        app.kubernetes.io/tracing: jaeger-agent
     spec:
       containers:
       - args:
@@ -75,12 +76,20 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         image: jaegertracing/jaeger-agent:1.14.0
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /
+            port: 14271
+            scheme: HTTP
         name: jaeger-agent
         ports:
         - containerPort: 6831
           name: jaeger-thrift
         - containerPort: 5778
           name: configs
+        - containerPort: 14271
+          name: metrics
         resources:
           limits:
             cpu: 128m

--- a/environments/kubernetes/manifests/thanos-querier-deployment.yaml
+++ b/environments/kubernetes/manifests/thanos-querier-deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: thanos-querier
+        app.kubernetes.io/tracing: jaeger-agent
     spec:
       containers:
       - args:
@@ -64,12 +65,20 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         image: jaegertracing/jaeger-agent:1.14.0
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /
+            port: 14271
+            scheme: HTTP
         name: jaeger-agent
         ports:
         - containerPort: 6831
           name: jaeger-thrift
         - containerPort: 5778
           name: configs
+        - containerPort: 14271
+          name: metrics
         resources:
           limits:
             cpu: 128m

--- a/environments/kubernetes/manifests/thanos-receive-statefulSet-default.yaml
+++ b/environments/kubernetes/manifests/thanos-receive-statefulSet-default.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: thanos-receive
+    app.kubernetes.io/tracing: jaeger-agent
     controller.receive.thanos.io: thanos-receive-controller
     controller.receive.thanos.io/hashring: default
   name: thanos-receive-default
@@ -96,12 +97,20 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         image: jaegertracing/jaeger-agent:1.14.0
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /
+            port: 14271
+            scheme: HTTP
         name: jaeger-agent
         ports:
         - containerPort: 6831
           name: jaeger-thrift
         - containerPort: 5778
           name: configs
+        - containerPort: 14271
+          name: metrics
         resources:
           limits:
             cpu: 128m

--- a/environments/kubernetes/manifests/thanos-store-statefulSet.yaml
+++ b/environments/kubernetes/manifests/thanos-store-statefulSet.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: thanos-store
+        app.kubernetes.io/tracing: jaeger-agent
     spec:
       containers:
       - args:
@@ -73,12 +74,20 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         image: jaegertracing/jaeger-agent:1.14.0
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /
+            port: 14271
+            scheme: HTTP
         name: jaeger-agent
         ports:
         - containerPort: 6831
           name: jaeger-thrift
         - containerPort: 5778
           name: configs
+        - containerPort: 14271
+          name: metrics
         resources:
           limits:
             cpu: 128m

--- a/environments/openshift/manifests/jaeger-template.yaml
+++ b/environments/openshift/manifests/jaeger-template.yaml
@@ -49,11 +49,12 @@ objects:
             value: badger
           image: ${IMAGE}:${IMAGE_TAG}
           livenessProbe:
-            failureThreshold: 3
+            failureThreshold: 4
             httpGet:
               path: /
               port: 14269
               scheme: HTTP
+            periodSeconds: 30
           name: jaeger-all-in-one
           ports:
           - containerPort: 14250
@@ -68,6 +69,8 @@ objects:
               path: /
               port: 14269
               scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
           resources:
             limits:
               cpu: "4"

--- a/environments/openshift/manifests/jaeger-template.yaml
+++ b/environments/openshift/manifests/jaeger-template.yaml
@@ -17,6 +17,20 @@ objects:
       targetPort: 14269
     selector:
       app.kubernetes.io/name: jaeger-all-in-one
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/name: jaeger-agent
+    name: jaeger-agent
+    namespace: ${NAMESPACE}
+  spec:
+    ports:
+    - name: metrics
+      port: 14271
+      targetPort: 14271
+    selector:
+      app.kubernetes.io/tracing: jaeger-agent
 - apiVersion: apps/v1
   kind: Deployment
   metadata:

--- a/environments/openshift/manifests/jaeger-template.yaml
+++ b/environments/openshift/manifests/jaeger-template.yaml
@@ -3,6 +3,20 @@ kind: Template
 metadata:
   name: jaeger
 objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/name: jaeger-all-in-one
+    name: jaeger-admin
+    namespace: ${NAMESPACE}
+  spec:
+    ports:
+    - name: admin-http
+      port: 14269
+      targetPort: 14269
+    selector:
+      app.kubernetes.io/name: jaeger-all-in-one
 - apiVersion: apps/v1
   kind: Deployment
   metadata:

--- a/environments/openshift/manifests/jaeger-template.yaml
+++ b/environments/openshift/manifests/jaeger-template.yaml
@@ -83,7 +83,7 @@ objects:
               path: /
               port: 14269
               scheme: HTTP
-            initialDelaySeconds: 30
+            initialDelaySeconds: 10
             periodSeconds: 30
           resources:
             limits:

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -34,6 +34,7 @@ objects:
       metadata:
         labels:
           app.kubernetes.io/name: thanos-compactor
+          app.kubernetes.io/tracing: jaeger-agent
       spec:
         containers:
         - args:
@@ -104,12 +105,20 @@ objects:
               fieldRef:
                 fieldPath: metadata.name
           image: ${JAEGER_AGENT_IMAGE}:${JAEGER_AGENT_IMAGE_TAG}
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /
+              port: 14271
+              scheme: HTTP
           name: jaeger-agent
           ports:
           - containerPort: 6831
             name: jaeger-thrift
           - containerPort: 5778
             name: configs
+          - containerPort: 14271
+            name: metrics
           resources:
             limits:
               cpu: 128m
@@ -282,6 +291,7 @@ objects:
       metadata:
         labels:
           app.kubernetes.io/name: thanos-querier
+          app.kubernetes.io/tracing: jaeger-agent
       spec:
         containers:
         - args:
@@ -332,12 +342,20 @@ objects:
               fieldRef:
                 fieldPath: metadata.name
           image: ${JAEGER_AGENT_IMAGE}:${JAEGER_AGENT_IMAGE_TAG}
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /
+              port: 14271
+              scheme: HTTP
           name: jaeger-agent
           ports:
           - containerPort: 6831
             name: jaeger-thrift
           - containerPort: 5778
             name: configs
+          - containerPort: 14271
+            name: metrics
           resources:
             limits:
               cpu: 128m
@@ -590,6 +608,7 @@ objects:
     labels:
       app.kubernetes.io/instance: default
       app.kubernetes.io/name: thanos-receive
+      app.kubernetes.io/tracing: jaeger-agent
       controller.receive.thanos.io: thanos-receive-controller
       controller.receive.thanos.io/hashring: default
     name: thanos-receive-default
@@ -692,12 +711,20 @@ objects:
               fieldRef:
                 fieldPath: metadata.name
           image: ${JAEGER_AGENT_IMAGE}:${JAEGER_AGENT_IMAGE_TAG}
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /
+              port: 14271
+              scheme: HTTP
           name: jaeger-agent
           ports:
           - containerPort: 6831
             name: jaeger-thrift
           - containerPort: 5778
             name: configs
+          - containerPort: 14271
+            name: metrics
           resources:
             limits:
               cpu: 128m
@@ -754,6 +781,7 @@ objects:
       metadata:
         labels:
           app.kubernetes.io/name: thanos-store
+          app.kubernetes.io/tracing: jaeger-agent
       spec:
         containers:
         - args:
@@ -822,12 +850,20 @@ objects:
               fieldRef:
                 fieldPath: metadata.name
           image: ${JAEGER_AGENT_IMAGE}:${JAEGER_AGENT_IMAGE_TAG}
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /
+              port: 14271
+              scheme: HTTP
           name: jaeger-agent
           ports:
           - containerPort: 6831
             name: jaeger-thrift
           - containerPort: 5778
             name: configs
+          - containerPort: 14271
+            name: metrics
           resources:
             limits:
               cpu: 128m
@@ -988,7 +1024,6 @@ objects:
           - --whitelist={__name__="openshift:memory_usage_bytes:sum"}
           - --whitelist={__name__="workload:cpu_usage_cores:sum"}
           - --whitelist={__name__="workload:memory_usage_bytes:sum"}
-          - --whitelist={__name__="cluster:virt_platform_nodes:sum"}
           - --whitelist={__name__="cluster:node_instance_type_count:sum"}
           - --whitelist={__name__="cnv:vmi_status_running:count"}
           - --whitelist={__name__="node_role_os_version_machine:cpu_capacity_cores:sum"}

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -1024,6 +1024,7 @@ objects:
           - --whitelist={__name__="openshift:memory_usage_bytes:sum"}
           - --whitelist={__name__="workload:cpu_usage_cores:sum"}
           - --whitelist={__name__="workload:memory_usage_bytes:sum"}
+          - --whitelist={__name__="cluster:virt_platform_nodes:sum"}
           - --whitelist={__name__="cluster:node_instance_type_count:sum"}
           - --whitelist={__name__="cnv:vmi_status_running:count"}
           - --whitelist={__name__="node_role_os_version_machine:cpu_capacity_cores:sum"}

--- a/environments/sre/servicemonitors/observatorium-jaeger-agent-stage.servicemonitor.yaml
+++ b/environments/sre/servicemonitors/observatorium-jaeger-agent-stage.servicemonitor.yaml
@@ -1,15 +1,15 @@
 apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
+kind: ServiceMonitor
 metadata:
   labels:
     prometheus: app-sre
   name: observatorium-jaeger-agent
 spec:
+  endpoints:
+  - port: metrics
   namespaceSelector:
     matchNames:
     - telemeter-stage
-  podMetricsEndpoints:
-  - targetPort: 14271
   selector:
     matchLabels:
-      app.kubernetes.io/tracing: jaeger-agent
+      app.kubernetes.io/name: jaeger-agent

--- a/environments/sre/servicemonitors/observatorium-jaeger-agent.servicemonitor.yaml
+++ b/environments/sre/servicemonitors/observatorium-jaeger-agent.servicemonitor.yaml
@@ -1,15 +1,15 @@
 apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
+kind: ServiceMonitor
 metadata:
   labels:
     prometheus: app-sre
   name: observatorium-jaeger-agent
 spec:
+  endpoints:
+  - port: metrics
   namespaceSelector:
     matchNames:
     - telemeter-production
-  podMetricsEndpoints:
-  - targetPort: 14271
   selector:
     matchLabels:
-      app.kubernetes.io/tracing: jaeger-agent
+      app.kubernetes.io/name: jaeger-agent

--- a/environments/sre/servicemonitors/observatorium-jaeger-stage.podmonitor.yaml
+++ b/environments/sre/servicemonitors/observatorium-jaeger-stage.podmonitor.yaml
@@ -1,15 +1,15 @@
 apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
+kind: PodMonitor
 metadata:
   labels:
     prometheus: app-sre
-  name: observatorium-jaeger-collector
+  name: observatorium-jaeger-agent
 spec:
-  endpoints:
-  - port: admin-http
   namespaceSelector:
     matchNames:
     - telemeter-stage
+  podMetricsEndpoints:
+  - targetPort: 14271
   selector:
     matchLabels:
-      app.kubernetes.io/name: jaeger-all-in-one
+      app.kubernetes.io/tracing: jaeger-agent

--- a/environments/sre/servicemonitors/observatorium-jaeger.podmonitor.yaml
+++ b/environments/sre/servicemonitors/observatorium-jaeger.podmonitor.yaml
@@ -1,15 +1,15 @@
 apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
+kind: PodMonitor
 metadata:
   labels:
     prometheus: app-sre
-  name: observatorium-jaeger-collector
+  name: observatorium-jaeger-agent
 spec:
-  endpoints:
-  - port: admin-http
   namespaceSelector:
     matchNames:
     - telemeter-production
+  podMetricsEndpoints:
+  - targetPort: 14271
   selector:
     matchLabels:
-      app.kubernetes.io/name: jaeger-all-in-one
+      app.kubernetes.io/tracing: jaeger-agent


### PR DESCRIPTION
This PR attempts to fix issues with monitoring jaeger components.

* Adds a new admin service for jaeger collector. (https://www.jaegertracing.io/docs/1.15/monitoring/)
* Fixes `ServiceMonitor` to point correct service.
* ~~Adds a `PodMonitor` to monitor `jaeger-agent`s~~
* Adds a `ServiceMonitor` to select and monitor `jaeger-agent`s
(https://www.jaegertracing.io/docs/1.15/deployment/#agent)
* Adds liveness probes for `jaeger-agent`s (https://github.com/jaegertracing/jaeger/blob/master/pkg/healthcheck/handler.go)

