### PR TITLE
Rename Jaeger Agent service

### DIFF
--- a/components/jaeger-collector.libsonnet
+++ b/components/jaeger-collector.libsonnet
@@ -49,7 +49,7 @@ local jaegerAgent = import './jaeger-agent.libsonnet';
 
     agentService:
       service.new(
-        'jaeger-agent',
+        'jaeger-agent-discovery',
         jaegerAgent.labels,
         [
           service.mixin.spec.portsType.newNamed('metrics', jaegerAgent.metricsPort, jaegerAgent.metricsPort),

--- a/environments/kubernetes/manifests/jaeger-agentService.yaml
+++ b/environments/kubernetes/manifests/jaeger-agentService.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: jaeger-agent
-  name: jaeger-agent
+  name: jaeger-agent-discovery
   namespace: observatorium
 spec:
   ports:

--- a/environments/openshift/manifests/jaeger-template.yaml
+++ b/environments/openshift/manifests/jaeger-template.yaml
@@ -22,7 +22,7 @@ objects:
   metadata:
     labels:
       app.kubernetes.io/name: jaeger-agent
-    name: jaeger-agent
+    name: jaeger-agent-discovery
     namespace: ${NAMESPACE}
   spec:
     ports:


### PR DESCRIPTION
This PR fixes the issue caused by the name of the service.
A similar issue could be found https://github.com/grafana/loki/issues/480