### PR TITLE
Increase jaeger agent memory limit

### DIFF
--- a/components/jaeger-agent.libsonnet
+++ b/components/jaeger-agent.libsonnet
@@ -15,8 +15,8 @@ local containerEnv = container.envType;
       containerEnv.fromFieldPath('NAMESPACE', 'metadata.namespace'),
       containerEnv.fromFieldPath('POD', 'metadata.name'),
     ]) +
-    container.mixin.resources.withRequests({ cpu: '32m', memory: '16Mi' }) +
-    container.mixin.resources.withLimits({ cpu: '128m', memory: '64Mi' }) +
+    container.mixin.resources.withRequests({ cpu: '32m', memory: '64Mi' }) +
+    container.mixin.resources.withLimits({ cpu: '128m', memory: '128Mi' }) +
     container.mixin.livenessProbe.withFailureThreshold(5) +
     container.mixin.livenessProbe.httpGet.withPath('/').withPort(self.metricsPort).withScheme('HTTP') +
     container.withPorts([

--- a/environments/kubernetes/manifests/thanos-compactor-statefulSet.yaml
+++ b/environments/kubernetes/manifests/thanos-compactor-statefulSet.yaml
@@ -93,10 +93,10 @@ spec:
         resources:
           limits:
             cpu: 128m
-            memory: 64Mi
+            memory: 128Mi
           requests:
             cpu: 32m
-            memory: 16Mi
+            memory: 64Mi
       volumes:
       - emptyDir: {}
         name: thanos-compactor-data

--- a/environments/kubernetes/manifests/thanos-querier-deployment.yaml
+++ b/environments/kubernetes/manifests/thanos-querier-deployment.yaml
@@ -82,7 +82,7 @@ spec:
         resources:
           limits:
             cpu: 128m
-            memory: 64Mi
+            memory: 128Mi
           requests:
             cpu: 32m
-            memory: 16Mi
+            memory: 64Mi

--- a/environments/kubernetes/manifests/thanos-receive-statefulSet-default.yaml
+++ b/environments/kubernetes/manifests/thanos-receive-statefulSet-default.yaml
@@ -114,10 +114,10 @@ spec:
         resources:
           limits:
             cpu: 128m
-            memory: 64Mi
+            memory: 128Mi
           requests:
             cpu: 32m
-            memory: 16Mi
+            memory: 64Mi
       volumes:
       - configMap:
           name: observatorium-tenants-generated

--- a/environments/kubernetes/manifests/thanos-store-statefulSet.yaml
+++ b/environments/kubernetes/manifests/thanos-store-statefulSet.yaml
@@ -91,10 +91,10 @@ spec:
         resources:
           limits:
             cpu: 128m
-            memory: 64Mi
+            memory: 128Mi
           requests:
             cpu: 32m
-            memory: 16Mi
+            memory: 64Mi
       volumes: null
   volumeClaimTemplates:
   - metadata:

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -122,10 +122,10 @@ objects:
           resources:
             limits:
               cpu: 128m
-              memory: 64Mi
+              memory: 128Mi
             requests:
               cpu: 32m
-              memory: 16Mi
+              memory: 64Mi
         volumes:
         - emptyDir: {}
           name: thanos-compactor-data
@@ -359,10 +359,10 @@ objects:
           resources:
             limits:
               cpu: 128m
-              memory: 64Mi
+              memory: 128Mi
             requests:
               cpu: 32m
-              memory: 16Mi
+              memory: 64Mi
         - args:
           - -provider=openshift
           - -https-address=:9091
@@ -735,10 +735,10 @@ objects:
           resources:
             limits:
               cpu: 128m
-              memory: 64Mi
+              memory: 128Mi
             requests:
               cpu: 32m
-              memory: 16Mi
+              memory: 64Mi
         volumes:
         - configMap:
             name: observatorium-tenants-generated
@@ -874,10 +874,10 @@ objects:
           resources:
             limits:
               cpu: 128m
-              memory: 64Mi
+              memory: 128Mi
             requests:
               cpu: 32m
-              memory: 16Mi
+              memory: 64Mi
         volumes: null
     volumeClaimTemplates:
     - metadata:


### PR DESCRIPTION
This PR increases the memory limits of jaeger-agents.

jaeger-agent, by default, allocates a queue to store spans before it sends it to the collector.
> Each queue is 1000 span batches. Given that each span batch has up to 64KiB worth of spans, each queue can hold up to 64MiB worth of span.

Normally this queue is mostly empty but when the collector is down it quickly reaches saturation. In our setup we have a limit of `64MiB` and it needs slightly more than that, so it gets OOMkilled.

ref: https://www.jaegertracing.io/docs/1.15/performance-tuning/#adjust-server-queue-sizes

cc @aditya-konarde @brancz @bwplotka 