### PR TITLE
Revert "Disable ServiceLinks for Cortex cache"

### DIFF
--- a/components/thanos-querier-cache.libsonnet
+++ b/components/thanos-querier-cache.libsonnet
@@ -83,7 +83,6 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         deployment.mixin.metadata.withNamespace('observatorium') +
         deployment.mixin.metadata.withLabels({ 'app.kubernetes.io/name': $.thanos.querierCache.deployment.metadata.name }) +
         deployment.mixin.spec.selector.withMatchLabels($.thanos.querierCache.deployment.metadata.labels) +
-        deployment.mixin.spec.template.spec.withEnableServiceLinks(false) +
         deployment.mixin.spec.template.spec.withVolumes([
           { name: 'querier-cache-config', configMap: { name: $.thanos.querierCache.configmap.metadata.name } },
         ]),

--- a/environments/kubernetes/manifests/thanos-querier-cache-deployment.yaml
+++ b/environments/kubernetes/manifests/thanos-querier-cache-deployment.yaml
@@ -33,7 +33,6 @@ spec:
         - mountPath: /etc/cache-config/
           name: querier-cache-config
           readOnly: false
-      enableServiceLinks: false
       volumes:
       - configMap:
           name: observatorium-cache-conf

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -234,7 +234,6 @@ objects:
           - mountPath: /etc/proxy/secrets
             name: secret-querier-cache-proxy
             readOnly: false
-        enableServiceLinks: false
         serviceAccount: prometheus-telemeter
         serviceAccountName: prometheus-telemeter
         volumes:


### PR DESCRIPTION
We don't have Kubernetes 1.13+ yet... :cry: 
This reverts commit ebf189d8280f2f852c1d07ec9fd4c0e153e13e7c.