### PR TITLE
Bug 1779912: Add a whitelist cluster:usage:* for telemetry for simple usage metric exposure

### DIFF
--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -1010,6 +1010,7 @@ objects:
           - --oidc-issuer=$(OIDC_ISSUER)
           - --client-id=$(CLIENT_ID)
           - --client-secret=$(CLIENT_SECRET)
+          - --whitelist={__name__=~"cluster:usage:.*"}
           - --whitelist={__name__="up"}
           - --whitelist={__name__="cluster_version"}
           - --whitelist={__name__="cluster_version_available_updates"}
@@ -1037,6 +1038,8 @@ objects:
           - --whitelist={__name__="node_role_os_version_machine:cpu_capacity_cores:sum"}
           - --whitelist={__name__="node_role_os_version_machine:cpu_capacity_sockets:sum"}
           - --whitelist={__name__="subscription_sync_total"}
+          - --whitelist={__name__="csv_succeeded"}
+          - --whitelist={__name__="csv_abnormal"}
           - --whitelist={__name__="ceph_cluster_total_bytes"}
           - --whitelist={__name__="ceph_cluster_total_used_raw_bytes"}
           - --whitelist={__name__="ceph_health_status"}
@@ -1053,6 +1056,7 @@ objects:
           - --whitelist={__name__="console_url"}
           - --whitelist={__name__="cluster:network_attachment_definition_instances:max"}
           - --whitelist={__name__="cluster:network_attachment_definition_enabled_instance_up:max"}
+          - --whitelist={__name__="insightsclient_request_send_total"}
           - --elide-label=prometheus_replica
           - --token-expire-seconds=3600
           - --forward-url=${TELEMETER_FORWARD_URL}

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -85,8 +85,8 @@
           "subdir": "jsonnet/telemeter"
         }
       },
-      "version": "9e11a67de0615ed863fa8d2fc2b1a5309f7a0a1b",
-      "sum": "ks15FK8j+RCu6QpmgI6Ofiy/RZ8eLQVss4VNo/IWQts="
+      "version": "8dae8893776e237688d7ff39821265a4f467f213",
+      "sum": "tLjALazakKQ6Z0VtG74rX/TLJo4Jh7lvN6fkXHWJxNc="
     },
     {
       "name": "thanos-mixin",


### PR DESCRIPTION
jsonnetfile: Bump to newer telemeter for cluster:usage:*