### PR TITLE
environments: add memcached to telemeter

### DIFF
--- a/environments/kubernetes/main.jsonnet
+++ b/environments/kubernetes/main.jsonnet
@@ -10,4 +10,5 @@ local app =
 { ['thanos-receive-controller-' + name]: app.thanos.receiveController[name] for name in std.objectFields(app.thanos.receiveController) } +
 { ['thanos-querier-cache-' + name]: app.thanos.querierCache[name] for name in std.objectFields(app.thanos.querierCache) } +
 { ['telemeter-' + name]: app.telemeterServer[name] for name in std.objectFields(app.telemeterServer) } +
+{ ['telemeter-memcached-' + name]: app.memcached[name] for name in std.objectFields(app.memcached) } +
 { ['jaeger-' + name]: app.jaeger[name] for name in std.objectFields(app.jaeger) }

--- a/environments/kubernetes/manifests/telemeter-memcached-service.yaml
+++ b/environments/kubernetes/manifests/telemeter-memcached-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: memcached
+  name: memcached
+  namespace: observatorium
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached
+    port: 11211
+    targetPort: 11211
+  selector:
+    app.kubernetes.io/name: memcached

--- a/environments/kubernetes/manifests/telemeter-memcached-statefulSet.yaml
+++ b/environments/kubernetes/manifests/telemeter-memcached-statefulSet.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1beta2
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/name: memcached
+  name: memcached
+  namespace: observatorium
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: memcached
+  serviceName: memcached
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: memcached
+    spec:
+      containers:
+      - image: docker.io/memcached:1.5.20-alpine
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: memcached
+        resources:
+          limits:
+            cpu: "1"
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 512Mi

--- a/environments/kubernetes/manifests/telemeter-statefulSet.yaml
+++ b/environments/kubernetes/manifests/telemeter-statefulSet.yaml
@@ -32,6 +32,7 @@ spec:
         - --oidc-issuer=$(OIDC_ISSUER)
         - --client-id=$(CLIENT_ID)
         - --client-secret=$(CLIENT_SECRET)
+        - --memcached=memcached-0.memcached.observatorium.svc.cluster.local:11211
         - --token-expire-seconds=3600
         - --forward-url=http://thanos-receive.observatorium.svc.cluster.local:19291/api/v1/receive
         env:

--- a/environments/kubernetes/telemeter.libsonnet
+++ b/environments/kubernetes/telemeter.libsonnet
@@ -31,4 +31,7 @@
       },
     },
   },
+  memcached+:: {
+    replicas:: 1,
+  },
 }

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -1010,6 +1010,7 @@ objects:
           - --oidc-issuer=$(OIDC_ISSUER)
           - --client-id=$(CLIENT_ID)
           - --client-secret=$(CLIENT_SECRET)
+          - --memcached=memcached-0.memcached.${NAMESPACE}.svc.cluster.local:11211
           - --whitelist={__name__=~"cluster:usage:.*"}
           - --whitelist={__name__="up"}
           - --whitelist={__name__="cluster_version"}
@@ -1118,6 +1119,52 @@ objects:
         - name: telemeter-server-tls
           secret:
             secretName: telemeter-server-shared
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/name: memcached
+    name: memcached
+    namespace: ${NAMESPACE}
+  spec:
+    clusterIP: None
+    ports:
+    - name: memcached
+      port: 11211
+      targetPort: 11211
+    selector:
+      app.kubernetes.io/name: memcached
+- apiVersion: apps/v1beta2
+  kind: StatefulSet
+  metadata:
+    labels:
+      app.kubernetes.io/name: memcached
+    name: memcached
+    namespace: ${NAMESPACE}
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: memcached
+    serviceName: memcached
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: memcached
+      spec:
+        containers:
+        - image: ${MEMCACHED_IMAGE}:${MEMCACHED_IMAGE_TAG}
+          name: memcached
+          ports:
+          - containerPort: 11211
+            name: memcached
+          resources:
+            limits:
+              cpu: "1"
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 512Mi
 - apiVersion: v1
   data:
     nginx.conf: |
@@ -1388,6 +1435,10 @@ parameters:
   value: 500Mi
 - name: TELEMETER_SERVER_MEMORY_LIMIT
   value: 1Gi
+- name: MEMCACHED_IMAGE
+  value: docker.io/memcached
+- name: MEMCACHED_IMAGE_TAG
+  value: 1.5.20-alpine
 - name: TELEMETER_FORWARD_URL
   value: ""
 - name: PROMETHEUS_AMS_REMOTE_WRITE_PROXY_IMAGE

--- a/environments/openshift/manifests/telemeter-template.yaml
+++ b/environments/openshift/manifests/telemeter-template.yaml
@@ -124,6 +124,7 @@ objects:
           - --oidc-issuer=$(OIDC_ISSUER)
           - --client-id=$(CLIENT_ID)
           - --client-secret=$(CLIENT_SECRET)
+          - --memcached=memcached-0.memcached.${NAMESPACE}.svc.cluster.local:11211
           - --whitelist={__name__=~"cluster:usage:.*"}
           - --whitelist={__name__="up"}
           - --whitelist={__name__="cluster_version"}
@@ -232,6 +233,52 @@ objects:
         - name: telemeter-server-tls
           secret:
             secretName: telemeter-server-shared
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/name: memcached
+    name: memcached
+    namespace: ${NAMESPACE}
+  spec:
+    clusterIP: None
+    ports:
+    - name: memcached
+      port: 11211
+      targetPort: 11211
+    selector:
+      app.kubernetes.io/name: memcached
+- apiVersion: apps/v1beta2
+  kind: StatefulSet
+  metadata:
+    labels:
+      app.kubernetes.io/name: memcached
+    name: memcached
+    namespace: ${NAMESPACE}
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: memcached
+    serviceName: memcached
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: memcached
+      spec:
+        containers:
+        - image: ${MEMCACHED_IMAGE}:${MEMCACHED_IMAGE_TAG}
+          name: memcached
+          ports:
+          - containerPort: 11211
+            name: memcached
+          resources:
+            limits:
+              cpu: "1"
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 512Mi
 parameters:
 - name: AUTHORIZE_URL
   value: https://api.openshift.com/api/accounts_mgmt/v1/cluster_registrations
@@ -249,3 +296,9 @@ parameters:
   value: 500Mi
 - name: TELEMETER_SERVER_MEMORY_LIMIT
   value: 1Gi
+- name: MEMCACHED_IMAGE
+  value: docker.io/memcached
+- name: MEMCACHED_IMAGE_TAG
+  value: 1.5.20-alpine
+- name: NAMESPACE
+  value: observatorium

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -85,8 +85,8 @@
           "subdir": "jsonnet/telemeter"
         }
       },
-      "version": "8dae8893776e237688d7ff39821265a4f467f213",
-      "sum": "tLjALazakKQ6Z0VtG74rX/TLJo4Jh7lvN6fkXHWJxNc="
+      "version": "9b1f70d49ab7a725a8aa99ad02445cd34ecccc65",
+      "sum": "2SA1mOuMSugKmmQXXWr3zUegrdGdtRsMheLtuPWYQE4="
     },
     {
       "name": "thanos-mixin",


### PR DESCRIPTION
This commit adds a Memcached StatefulSet with one replica to the
Telemeter OpenShift template and configures telemeter-server to use it
for caching authentication responses to requests made to the
remote-write endpoint. Before merging this, we need to bump the
telemeter-server image tag to include the caching code.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @metalmatze @kakkoyun @brancz @bwplotka @aditya-konarde 