### PR TITLE
environments: resource requests/limits on exporter

### DIFF
--- a/environments/kubernetes/manifests/telemeter-memcached-statefulSet.yaml
+++ b/environments/kubernetes/manifests/telemeter-memcached-statefulSet.yaml
@@ -38,7 +38,7 @@ spec:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
         image: docker.io/prom/memcached-exporter:v0.6.0
-        name: exporter
+        name: memcached-exporter
         ports:
         - containerPort: 9150
           name: metrics

--- a/environments/kubernetes/telemeter.libsonnet
+++ b/environments/kubernetes/telemeter.libsonnet
@@ -33,5 +33,20 @@
   },
   memcached+:: {
     replicas:: 1,
+
+    statefulSet+: {
+      spec+: {
+        template+: {
+          spec+: {
+            containers: [
+              super.containers[0],
+              super.containers[1] {
+                name: 'memcached-exporter',
+              },
+            ],
+          },
+        },
+      },
+    },
   },
 }

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -1232,10 +1232,17 @@ objects:
           - --memcached.address=localhost:11211
           - --web.listen-address=0.0.0.0:9150
           image: ${MEMCACHED_EXPORTER_IMAGE}:${MEMCACHED_EXPORTER_IMAGE_TAG}
-          name: exporter
+          name: memcached-exporter
           ports:
           - containerPort: 9150
             name: metrics
+          resources:
+            limits:
+              cpu: ${MEMCACHED_EXPORTER_CPU_LIMIT}
+              memory: ${MEMCACHED_EXPORTER_MEMORY_LIMIT}
+            requests:
+              cpu: ${MEMCACHED_EXPORTER_CPU_REQUEST}
+              memory: ${MEMCACHED_EXPORTER_MEMORY_REQUEST}
 - apiVersion: v1
   data:
     nginx.conf: |
@@ -1522,6 +1529,14 @@ parameters:
   value: 1329Mi
 - name: MEMCACHED_MEMORY_LIMIT
   value: 1844Mi
+- name: MEMCACHED_EXPORTER_CPU_REQUEST
+  value: 50m
+- name: MEMCACHED_EXPORTER_CPU_LIMIT
+  value: 200m
+- name: MEMCACHED_EXPORTER_MEMORY_REQUEST
+  value: 50Mi
+- name: MEMCACHED_EXPORTER_MEMORY_LIMIT
+  value: 200Mi
 - name: TELEMETER_FORWARD_URL
   value: ""
 - name: PROMETHEUS_AMS_REMOTE_WRITE_PROXY_IMAGE

--- a/environments/openshift/manifests/telemeter-template.yaml
+++ b/environments/openshift/manifests/telemeter-template.yaml
@@ -306,10 +306,17 @@ objects:
           - --memcached.address=localhost:11211
           - --web.listen-address=0.0.0.0:9150
           image: ${MEMCACHED_EXPORTER_IMAGE}:${MEMCACHED_EXPORTER_IMAGE_TAG}
-          name: exporter
+          name: memcached-exporter
           ports:
           - containerPort: 9150
             name: metrics
+          resources:
+            limits:
+              cpu: ${MEMCACHED_EXPORTER_CPU_LIMIT}
+              memory: ${MEMCACHED_EXPORTER_MEMORY_LIMIT}
+            requests:
+              cpu: ${MEMCACHED_EXPORTER_CPU_REQUEST}
+              memory: ${MEMCACHED_EXPORTER_MEMORY_REQUEST}
 parameters:
 - name: AUTHORIZE_URL
   value: https://api.openshift.com/api/accounts_mgmt/v1/cluster_registrations
@@ -343,5 +350,13 @@ parameters:
   value: 1329Mi
 - name: MEMCACHED_MEMORY_LIMIT
   value: 1844Mi
+- name: MEMCACHED_EXPORTER_CPU_REQUEST
+  value: 50m
+- name: MEMCACHED_EXPORTER_CPU_LIMIT
+  value: 200m
+- name: MEMCACHED_EXPORTER_MEMORY_REQUEST
+  value: 50Mi
+- name: MEMCACHED_EXPORTER_MEMORY_LIMIT
+  value: 200Mi
 - name: NAMESPACE
   value: observatorium

--- a/environments/openshift/telemeter.jsonnet
+++ b/environments/openshift/telemeter.jsonnet
@@ -50,6 +50,7 @@ local list = import 'telemeter/lib/list.libsonnet';
                   },
                 ])
                 + list.withResourceRequestsAndLimits('memcached', $.memcached.resourceRequests, $.memcached.resourceLimits)
+                + list.withResourceRequestsAndLimits('memcached-exporter', { cpu: '50m', memory: '50Mi' }, { cpu: '200m', memory: '200Mi' })
                 + list.withNamespace($._config),
 
   telemeterServer+:: {


### PR DESCRIPTION
This commit adds resource requests and limits to the Memcached exporter
container, as required by CI.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @kakkoyun @brancz @metalmatze @aditya-konarde 