### PR TITLE
Consume authorize_url from Secret

### DIFF
--- a/environments/kubernetes/manifests/telemeter-secret.yaml
+++ b/environments/kubernetes/manifests/telemeter-secret.yaml
@@ -1,5 +1,6 @@
 apiVersion: v1
 data:
+  authorize_url: ""
   client_id: ""
   client_secret: ""
   oidc_issuer: ""

--- a/environments/kubernetes/manifests/telemeter-statefulSet.yaml
+++ b/environments/kubernetes/manifests/telemeter-statefulSet.yaml
@@ -28,7 +28,7 @@ spec:
         - --tls-crt=/etc/pki/service/tls.crt
         - --internal-tls-key=/etc/pki/service/tls.key
         - --internal-tls-crt=/etc/pki/service/tls.crt
-        - --authorize=https://api.openshift.com/api/accounts_mgmt/v1/cluster_registrations
+        - --authorize=$(AUTHORIZE_URL)
         - --oidc-issuer=$(OIDC_ISSUER)
         - --client-id=$(CLIENT_ID)
         - --client-secret=$(CLIENT_SECRET)
@@ -40,6 +40,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: AUTHORIZE_URL
+          valueFrom:
+            secretKeyRef:
+              key: authorize_url
+              name: telemeter-server
         - name: OIDC_ISSUER
           valueFrom:
             secretKeyRef:

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -1419,6 +1419,7 @@ objects:
           severity: critical
 - apiVersion: v1
   data:
+    authorize_url: ""
     client_id: ""
     client_secret: ""
     oidc_issuer: ""

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -1534,7 +1534,7 @@ objects:
           - --tls-crt=/etc/pki/service/tls.crt
           - --internal-tls-key=/etc/pki/service/tls.key
           - --internal-tls-crt=/etc/pki/service/tls.crt
-          - --authorize=${AUTHORIZE_URL}
+          - --authorize=$(AUTHORIZE_URL)
           - --oidc-issuer=$(OIDC_ISSUER)
           - --client-id=$(CLIENT_ID)
           - --client-secret=$(CLIENT_SECRET)
@@ -1594,6 +1594,11 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          - name: AUTHORIZE_URL
+            valueFrom:
+              secretKeyRef:
+                key: authorize_url
+                name: telemeter-server
           - name: OIDC_ISSUER
             valueFrom:
               secretKeyRef:
@@ -1997,8 +2002,6 @@ parameters:
   value: 200m
 - name: JAEGER_PROXY_MEMORY_LIMITS
   value: 200Mi
-- name: AUTHORIZE_URL
-  value: https://api.openshift.com/api/accounts_mgmt/v1/cluster_registrations
 - name: IMAGE
   value: quay.io/openshift/origin-telemeter
 - name: IMAGE_TAG

--- a/environments/openshift/manifests/telemeter-template.yaml
+++ b/environments/openshift/manifests/telemeter-template.yaml
@@ -5,6 +5,7 @@ metadata:
 objects:
 - apiVersion: v1
   data:
+    authorize_url: ""
     client_id: ""
     client_secret: ""
     oidc_issuer: ""

--- a/environments/openshift/manifests/telemeter-template.yaml
+++ b/environments/openshift/manifests/telemeter-template.yaml
@@ -120,7 +120,7 @@ objects:
           - --tls-crt=/etc/pki/service/tls.crt
           - --internal-tls-key=/etc/pki/service/tls.key
           - --internal-tls-crt=/etc/pki/service/tls.crt
-          - --authorize=${AUTHORIZE_URL}
+          - --authorize=$(AUTHORIZE_URL)
           - --oidc-issuer=$(OIDC_ISSUER)
           - --client-id=$(CLIENT_ID)
           - --client-secret=$(CLIENT_SECRET)
@@ -180,6 +180,11 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          - name: AUTHORIZE_URL
+            valueFrom:
+              secretKeyRef:
+                key: authorize_url
+                name: telemeter-server
           - name: OIDC_ISSUER
             valueFrom:
               secretKeyRef:
@@ -318,8 +323,6 @@ objects:
               cpu: ${MEMCACHED_EXPORTER_CPU_REQUEST}
               memory: ${MEMCACHED_EXPORTER_MEMORY_REQUEST}
 parameters:
-- name: AUTHORIZE_URL
-  value: https://api.openshift.com/api/accounts_mgmt/v1/cluster_registrations
 - name: NAMESPACE
   value: observatorium
 - name: IMAGE

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -96,8 +96,8 @@
           "subdir": "jsonnet/telemeter"
         }
       },
-      "version": "04e896229a25482642a38937d9ff452302710ac6",
-      "sum": "s62onQakVZ2xrTyahP9G3gVMu+ovTG9STA8PukCJy3U="
+      "version": "c00c46c43677bf0c73a8f3d4fdc7fdad07d14954",
+      "sum": "Rux+eJyhxygzgTCcUWfomfSezL39Vj/Xfy7xopIDy+o="
     },
     {
       "name": "thanos-mixin",


### PR DESCRIPTION
This PR intends to take the authorization URL out of the template and into the telemeter-server Secret.

Please let me know if you think this is a good idea!

Can you also point out where I'm missing a change in jsonnet?
Update: depends on https://github.com/openshift/telemeter/pull/288

Thanks!