### PR TITLE
Add replica-label=ruler_replica to querier for dedup

### DIFF
--- a/environments/kubernetes/kube-thanos.libsonnet
+++ b/environments/kubernetes/kube-thanos.libsonnet
@@ -100,6 +100,7 @@ local capitalize(str) =
                   args: [
                     'query',
                     '--query.replica-label=replica',
+                    '--query.replica-label=ruler_replica',
                     '--query.replica-label=prometheus_replica',
                     '--grpc-address=0.0.0.0:%d' % $.thanos.querier.service.spec.ports[0].port,
                     '--http-address=0.0.0.0:%d' % $.thanos.querier.service.spec.ports[1].port,

--- a/environments/kubernetes/manifests/thanos-querier-deployment.yaml
+++ b/environments/kubernetes/manifests/thanos-querier-deployment.yaml
@@ -34,6 +34,7 @@ spec:
       - args:
         - query
         - --query.replica-label=replica
+        - --query.replica-label=ruler_replica
         - --query.replica-label=prometheus_replica
         - --grpc-address=0.0.0.0:10901
         - --http-address=0.0.0.0:9090

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -39,6 +39,7 @@ objects:
         - args:
           - query
           - --query.replica-label=replica
+          - --query.replica-label=ruler_replica
           - --query.replica-label=prometheus_replica
           - --grpc-address=0.0.0.0:10901
           - --http-address=0.0.0.0:9090

--- a/environments/openshift/manifests/thanos-template.yaml
+++ b/environments/openshift/manifests/thanos-template.yaml
@@ -39,6 +39,7 @@ objects:
         - args:
           - query
           - --query.replica-label=replica
+          - --query.replica-label=ruler_replica
           - --query.replica-label=prometheus_replica
           - --grpc-address=0.0.0.0:10901
           - --http-address=0.0.0.0:9090


### PR DESCRIPTION
As we override the args for the Thanos Querier entirely, we simply need to add the flag as is.

/cc @aditya-konarde @squat 