### PR TITLE
openshift: thanos receive guaranteed QoS

### DIFF
--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -2213,11 +2213,11 @@ parameters:
 - name: THANOS_STORE_MEMORY_LIMIT
   value: 8Gi
 - name: THANOS_RECEIVE_CPU_REQUEST
-  value: 100m
+  value: "1"
 - name: THANOS_RECEIVE_CPU_LIMIT
   value: "1"
 - name: THANOS_RECEIVE_MEMORY_REQUEST
-  value: 512Mi
+  value: 1Gi
 - name: THANOS_RECEIVE_MEMORY_LIMIT
   value: 1Gi
 - name: THANOS_COMPACTOR_CPU_REQUEST

--- a/environments/openshift/obs.jsonnet
+++ b/environments/openshift/obs.jsonnet
@@ -502,7 +502,7 @@ local cqf = (import '../../components/cortex-query-frontend.libsonnet');
       },
       {
         name: 'THANOS_RECEIVE_CPU_REQUEST',
-        value: '100m',
+        value: '1',
       },
       {
         name: 'THANOS_RECEIVE_CPU_LIMIT',
@@ -510,7 +510,7 @@ local cqf = (import '../../components/cortex-query-frontend.libsonnet');
       },
       {
         name: 'THANOS_RECEIVE_MEMORY_REQUEST',
-        value: '512Mi',
+        value: '1Gi',
       },
       {
         name: 'THANOS_RECEIVE_MEMORY_LIMIT',


### PR DESCRIPTION
This commit is a follow up from previous incidents. It puts the Thanos
receiver in the QoS class. This will also give yield more consistent
scaling characteristics once we introduce HPA.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

This is a follow up from our last incident.

cc @metalmatze @brancz @kakkoyun 