### PR TITLE
environments/openshift: Remove web external prefix

### DIFF
--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -370,7 +370,6 @@ objects:
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-rule.${NAMESPACE}.svc.cluster.local
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-store.${NAMESPACE}.svc.cluster.local
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-receive-default.${NAMESPACE}.svc.cluster.local
-          - --web.external-prefix=/ui/v1/metrics
           - |
             --tracing.config=
               type: JAEGER

--- a/environments/openshift/obs.jsonnet
+++ b/environments/openshift/obs.jsonnet
@@ -112,7 +112,6 @@ local cqf = (import '../../components/cortex-query-frontend.libsonnet');
 
   query+::
     t.query.withResources +
-    t.query.withExternalPrefix +
     (import '../../components/oauth-proxy.libsonnet') +
     (import '../../components/jaeger-agent.libsonnet').deploymentMixin,
 


### PR DESCRIPTION
Removing for now as we're still testing this on stage with the obs API but we can't promote this to prod without the API which we're not intending to do yet.

@squat @metalmatze @kakkoyun @bwplotka @krasi-georgiev 