### PR TITLE
use authorize-url from Secret - attempt #2

### DIFF
--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -2301,7 +2301,7 @@ objects:
           - --tls-crt=/etc/pki/service/tls.crt
           - --internal-tls-key=/etc/pki/service/tls.key
           - --internal-tls-crt=/etc/pki/service/tls.crt
-          - --authorize=${AUTHORIZE_URL}
+          - --authorize=$(AUTHORIZE_URL)
           - --oidc-issuer=$(OIDC_ISSUER)
           - --client-id=$(CLIENT_ID)
           - --client-secret=$(CLIENT_SECRET)
@@ -2361,6 +2361,15 @@ objects:
           - --token-expire-seconds=3600
           - --forward-url=${TELEMETER_FORWARD_URL}
           env:
+          - name: NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: AUTHORIZE_URL
+            valueFrom:
+              secretKeyRef:
+                key: authorize_url
+                name: telemeter-server
           - name: OIDC_ISSUER
             valueFrom:
               secretKeyRef:
@@ -2776,8 +2785,6 @@ parameters:
   value: 200m
 - name: JAEGER_PROXY_MEMORY_LIMITS
   value: 200Mi
-- name: AUTHORIZE_URL
-  value: https://api.openshift.com/api/accounts_mgmt/v1/cluster_registrations
 - name: IMAGE
   value: quay.io/openshift/origin-telemeter
 - name: IMAGE_TAG

--- a/environments/openshift/obs.jsonnet
+++ b/environments/openshift/obs.jsonnet
@@ -740,10 +740,6 @@ local up = (import '../../components/up.libsonnet');
         value: '200Mi',
       },
       {
-        name: 'AUTHORIZE_URL',
-        value: 'https://api.openshift.com/api/accounts_mgmt/v1/cluster_registrations',
-      },
-      {
         name: 'IMAGE',
         value: 'quay.io/openshift/origin-telemeter',
       },


### PR DESCRIPTION
This PR intends to take the authorization URL out of the template and into the telemeter-server Secret.

replaces #149 