### PR TITLE
WIP: Change storageclass on OpenShift manifests to gp2

### DIFF
--- a/environments/openshift/jaeger.jsonnet
+++ b/environments/openshift/jaeger.jsonnet
@@ -7,7 +7,7 @@ local app =
       image:: '${IMAGE}:${IMAGE_TAG}',
       replicas:: '${{REPLICAS}}',  // additional parenthesis does matter, they convert argument to an int.
       pvc+:: {
-        class: 'gp2-encrypted',
+        class: 'gp2',
       },
 
       queryService+: {

--- a/environments/openshift/manifests/jaeger-template.yaml
+++ b/environments/openshift/manifests/jaeger-template.yaml
@@ -282,7 +282,7 @@ objects:
     resources:
       requests:
         storage: 50Gi
-    storageClassName: gp2-encrypted
+    storageClassName: gp2
 parameters:
 - name: NAMESPACE
   value: telemeter

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -917,7 +917,7 @@ objects:
         resources:
           requests:
             storage: 50Gi
-        storageClassName: gp2-encrypted
+        storageClassName: gp2
 - apiVersion: v1
   kind: Service
   metadata:
@@ -1257,7 +1257,7 @@ objects:
         resources:
           requests:
             storage: 50Gi
-        storageClassName: gp2-encrypted
+        storageClassName: gp2
 - apiVersion: v1
   kind: Service
   metadata:

--- a/environments/openshift/obs.jsonnet
+++ b/environments/openshift/obs.jsonnet
@@ -224,7 +224,7 @@ local cqf = (import '../../components/cortex-query-frontend.libsonnet');
               storage: '50Gi',
             },
           },
-          storageClassName: 'gp2-encrypted',
+          storageClassName: 'gp2',
         },
       },
       jaegerAgent: {
@@ -277,7 +277,7 @@ local cqf = (import '../../components/cortex-query-frontend.libsonnet');
               storage: '50Gi',
             },
           },
-          storageClassName: 'gp2-encrypted',
+          storageClassName: 'gp2',
         },
       },
       jaegerAgent: {


### PR DESCRIPTION
OSDv4 doesn't have a storageclass called `gp2-encrypted` but instead has `gp2`. Changing this in advance so that we don't fail on first deploy :)