### PR TITLE
components/jaeger: Reduce retention to 3h

### DIFF
--- a/components/jaeger-collector.libsonnet
+++ b/components/jaeger-collector.libsonnet
@@ -85,6 +85,7 @@ local jaegerAgent = import './jaeger-agent.libsonnet';
           '--badger.directory-key=/var/jaeger/store/keys',
           '--badger.directory-value=/var/jaeger/store/values',
           '--badger.ephemeral=false',
+          '--badger.span-store-ttl=3h',
           '--collector.queue-size=4000',
         ],) +
         container.withEnv([

--- a/environments/openshift/manifests/jaeger-template.yaml
+++ b/environments/openshift/manifests/jaeger-template.yaml
@@ -57,6 +57,7 @@ objects:
           - --badger.directory-key=/var/jaeger/store/keys
           - --badger.directory-value=/var/jaeger/store/values
           - --badger.ephemeral=false
+          - --badger.span-store-ttl=3h
           - --collector.queue-size=4000
           env:
           - name: SPAN_STORAGE_TYPE


### PR DESCRIPTION
By default the retention is 72h, which at consistent load explodes with
the 50G disk.

https://www.jaegertracing.io/docs/1.17/cli/#jaeger-all-in-one-badger

@squat @metalmatze @bwplotka @krasi-georgiev @aditya-konarde 
