### PR TITLE
jsonnet: bump telemeter to remove gossip

### DIFF
--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -2026,9 +2026,6 @@ objects:
     - name: internal
       port: 8081
       targetPort: internal
-    - name: cluster
-      port: 8082
-      targetPort: cluster
     selector:
       k8s-app: telemeter-server
 - apiVersion: v1
@@ -2103,11 +2100,8 @@ objects:
         containers:
         - command:
           - /usr/bin/telemeter-server
-          - --join=telemeter-server
-          - --name=$(NAME)
           - --listen=0.0.0.0:8443
           - --listen-internal=0.0.0.0:8081
-          - --listen-cluster=0.0.0.0:8082
           - --shared-key=/etc/pki/service/tls.key
           - --tls-key=/etc/pki/service/tls.key
           - --tls-crt=/etc/pki/service/tls.crt
@@ -2173,10 +2167,6 @@ objects:
           - --token-expire-seconds=3600
           - --forward-url=${TELEMETER_FORWARD_URL}
           env:
-          - name: NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
           - name: OIDC_ISSUER
             valueFrom:
               secretKeyRef:
@@ -2204,8 +2194,6 @@ objects:
             name: external
           - containerPort: 8081
             name: internal
-          - containerPort: 8082
-            name: cluster
           readinessProbe:
             httpGet:
               path: /healthz/ready

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -30,7 +30,7 @@
           "subdir": "monitoring/jaeger-mixin"
         }
       },
-      "version": "bf48066125f33c9fcc5ad3a3f423a1527b22b6e4",
+      "version": "cc283fbd6b01e687f54a1ee9412c5ae1130da667",
       "sum": "U/RwaRP/ps+5dVyeVxeFEb2psfZHQgEjHU2Jeb454Kg="
     },
     {
@@ -85,8 +85,8 @@
           "subdir": "jsonnet/telemeter"
         }
       },
-      "version": "5d35babadf734c4ae6d16b6b4f9c4ef582a8a695",
-      "sum": "4lnWwMNjrA7Rl7wYRkEm21xj+UvWRj8JgG9ScKtRWDM="
+      "version": "fa41a6ae349cf5a54dd975703676bfad351992fb",
+      "sum": "7N1rtI+xIs5b2itzPk/rvHlHkQ+94w1P9REcjlhbaDQ="
     },
     {
       "name": "thanos-mixin",


### PR DESCRIPTION
This commit bumps the Telemeter dependency to remove the gossip flags
from the configuration. It also has the side effect of eliminating the
prometheus-operator jsonnet dependency :)

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @brancz @aditya-konarde @metalmatze 