### PR TITLE
Test operator with image build on PR

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,6 +20,7 @@ spec:
       containers:
       - name: observatorium-operator
         image: quay.io/observatorium/observatorium-operator:latest
+        imagePullPolicy: IfNotPresent
         args:
           - "--log-level=debug"
         resources:

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -45,6 +45,8 @@ wait_for_cr() {
 }
 
 deploy_operator() {
+    docker build -t quay.io/observatorium/observatorium-operator:latest .
+    ./kind load docker-image quay.io/observatorium/observatorium-operator:latest
     $KUBECTL apply -f https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/setup/prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
     $KUBECTL apply -f https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/setup/prometheus-operator-0prometheusruleCustomResourceDefinition.yaml
     $KUBECTL create ns minio || true


### PR DESCRIPTION
The current test is pulling the latest image from quay, so it is not testing the changes introduced in PRs.

With this change, an image is build based on the PR and loaded in the cluster using `kind load docker-image`.