### PR TITLE
cortex-query-frontend: Adjust various querying timeouts

### DIFF
--- a/components/cortex-query-frontend.libsonnet
+++ b/components/cortex-query-frontend.libsonnet
@@ -91,6 +91,9 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         '-log.level=debug',
         '-config.file=/etc/cache-config/config.yaml',
         '-querier.max-retries-per-request=0',
+        '-server.http-read-timeout=900s',
+        '-server.http-write-timeout=900s',
+        '-querier.timeout=900s',
         '-frontend.downstream-url=' + cq.config.downstreamURL,
       ]) + container.withPorts([
         containerPort.newNamed(9090, 'http'),

--- a/environments/base/manifests/query-cache-deployment.yaml
+++ b/environments/base/manifests/query-cache-deployment.yaml
@@ -31,6 +31,9 @@ spec:
         - -log.level=debug
         - -config.file=/etc/cache-config/config.yaml
         - -querier.max-retries-per-request=0
+        - -server.http-read-timeout=900s
+        - -server.http-write-timeout=900s
+        - -querier.timeout=900s
         - -frontend.downstream-url=http://observatorium-xyz-thanos-query.observatorium.svc.cluster.local.:9090
         image: quay.io/cortexproject/cortex:master-fdcd992f
         name: cortex-query-frontend

--- a/environments/dev/manifests/query-cache-deployment.yaml
+++ b/environments/dev/manifests/query-cache-deployment.yaml
@@ -31,6 +31,9 @@ spec:
         - -log.level=debug
         - -config.file=/etc/cache-config/config.yaml
         - -querier.max-retries-per-request=0
+        - -server.http-read-timeout=900s
+        - -server.http-write-timeout=900s
+        - -querier.timeout=900s
         - -frontend.downstream-url=http://observatorium-xyz-thanos-query.observatorium.svc.cluster.local.:9090
         image: quay.io/cortexproject/cortex:master-fdcd992f
         name: cortex-query-frontend

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -391,6 +391,9 @@ objects:
           - -log.level=debug
           - -config.file=/etc/cache-config/config.yaml
           - -querier.max-retries-per-request=0
+          - -server.http-read-timeout=900s
+          - -server.http-write-timeout=900s
+          - -querier.timeout=900s
           - -frontend.downstream-url=http://observatorium-thanos-query.${NAMESPACE}.svc.cluster.local.:9090
           image: quay.io/cortexproject/cortex:master-fdcd992f
           name: cortex-query-frontend


### PR DESCRIPTION
This configures various timeouts in the system to be 15min by default.

@bwplotka @metalmatze @squat @krasi-georgiev @kakkoyun 