### PR TITLE
WIP: Enable offline deduplication

### DIFF
--- a/components/observatorium.libsonnet
+++ b/components/observatorium.libsonnet
@@ -9,18 +9,21 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       'app.kubernetes.io/part-of': 'observatorium',
       'app.kubernetes.io/instance': obs.config.name,
     },
+    replicaLabels:: ['prometheus_replica', 'rule_replica', 'replica'],
   },
 
   compact::
     t.compact +
     t.compact.withRetention +
-    t.compact.withDownsamplingDisabled + {
+    t.compact.withDownsamplingDisabled +
+    t.compact.withDeduplication + {
       config+:: {
         local cfg = self,
         name: obs.config.name + '-' + cfg.commonLabels['app.kubernetes.io/name'],
         namespace: obs.config.namespace,
         replicas: 1,
         commonLabels+:: obs.config.commonLabels,
+        deduplicationReplicaLabels: obs.config.replicaLabels,
       },
     },
 
@@ -129,7 +132,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           [obs.store[shard].service for shard in std.objectFields(obs.store)] +
           [obs.receivers[hashring].service for hashring in std.objectFields(obs.receivers)]
       ],
-      replicaLabels: ['prometheus_replica', 'rule_replica', 'replica'],
+      replicaLabels: obs.config.replicaLabels,
     },
   },
 

--- a/components/observatorium.libsonnet
+++ b/components/observatorium.libsonnet
@@ -16,6 +16,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     t.compact +
     t.compact.withRetention +
     t.compact.withDownsamplingDisabled +
+    t.compact.withDeleteDelay +
     t.compact.withDeduplication + {
       config+:: {
         local cfg = self,
@@ -24,6 +25,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         replicas: 1,
         commonLabels+:: obs.config.commonLabels,
         deduplicationReplicaLabels: obs.config.replicaLabels,
+        deleteDelay: '4h',
       },
     },
 
@@ -78,7 +80,8 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
 
   store:: {
     ['shard' + i]:
-      t.store {
+      t.store +
+      t.store.withIgnoreDeletionMarksDelay {
         config+:: {
           local cfg = self,
           name: obs.config.name + '-' + cfg.commonLabels['app.kubernetes.io/name'] + '-shard-' + i,
@@ -87,6 +90,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
             'store.observatorium.io/shard': 'shard-' + i,
           },
           replicas: 1,
+          ignoreDeletionMarksDelay: '1h',
         },
       } + {
         statefulSet+: {

--- a/environments/base/default-config.libsonnet
+++ b/environments/base/default-config.libsonnet
@@ -3,7 +3,7 @@
 
   name: 'observatorium-xyz',
   namespace: 'observatorium',
-  thanosVersion: 'master-2020-02-13-adfef4b5',
+  thanosVersion: 'master-2020-03-24-4bd19b16',
   thanosImage: 'quay.io/thanos/thanos:' + defaultConfig.thanosVersion,
   objectStorageConfig: {
     name: 'thanos-objectstorage',

--- a/environments/base/manifests/api-gateway-thanos-query-deployment.yaml
+++ b/environments/base/manifests/api-gateway-thanos-query-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz-api-gateway
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
   name: observatorium-xyz-observatorium-api-gateway-thanos-query
   namespace: observatorium
 spec:
@@ -24,7 +24,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz-api-gateway
         app.kubernetes.io/name: thanos-query
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: master-2020-02-13-adfef4b5
+        app.kubernetes.io/version: master-2020-03-24-4bd19b16
     spec:
       affinity:
         podAntiAffinity:
@@ -53,7 +53,7 @@ spec:
         - --store=dnssrv+_grpc._tcp.observatorium-xyz-thanos-store-shard-0.observatorium.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.observatorium-xyz-thanos-receive-default.observatorium.svc.cluster.local
         - --web.external-prefix=/ui/v1/metrics
-        image: quay.io/thanos/thanos:master-2020-02-13-adfef4b5
+        image: quay.io/thanos/thanos:master-2020-03-24-4bd19b16
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/environments/base/manifests/api-gateway-thanos-query-service.yaml
+++ b/environments/base/manifests/api-gateway-thanos-query-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz-api-gateway
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
   name: observatorium-xyz-observatorium-api-gateway-thanos-query
   namespace: observatorium
 spec:

--- a/environments/base/manifests/thanos-compact-service.yaml
+++ b/environments/base/manifests/thanos-compact-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-compact
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
   name: observatorium-xyz-thanos-compact
   namespace: observatorium
 spec:

--- a/environments/base/manifests/thanos-compact-statefulSet.yaml
+++ b/environments/base/manifests/thanos-compact-statefulSet.yaml
@@ -38,6 +38,7 @@ spec:
         - --retention.resolution-5m=1s
         - --retention.resolution-1h=1s
         - --downsampling.disable
+        - --delete-delay=4h
         - --deduplication.replica-label=prometheus_replica
         - --deduplication.replica-label=rule_replica
         - --deduplication.replica-label=replica

--- a/environments/base/manifests/thanos-compact-statefulSet.yaml
+++ b/environments/base/manifests/thanos-compact-statefulSet.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-compact
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
   name: observatorium-xyz-thanos-compact
   namespace: observatorium
 spec:
@@ -25,7 +25,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: thanos-compact
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: master-2020-02-13-adfef4b5
+        app.kubernetes.io/version: master-2020-03-24-4bd19b16
     spec:
       containers:
       - args:
@@ -44,7 +44,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-02-13-adfef4b5
+        image: quay.io/thanos/thanos:master-2020-03-24-4bd19b16
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/environments/base/manifests/thanos-compact-statefulSet.yaml
+++ b/environments/base/manifests/thanos-compact-statefulSet.yaml
@@ -38,6 +38,9 @@ spec:
         - --retention.resolution-5m=1s
         - --retention.resolution-1h=1s
         - --downsampling.disable
+        - --deduplication.replica-label=prometheus_replica
+        - --deduplication.replica-label=rule_replica
+        - --deduplication.replica-label=replica
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:

--- a/environments/base/manifests/thanos-query-deployment.yaml
+++ b/environments/base/manifests/thanos-query-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
   name: observatorium-xyz-thanos-query
   namespace: observatorium
 spec:
@@ -24,7 +24,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: thanos-query
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: master-2020-02-13-adfef4b5
+        app.kubernetes.io/version: master-2020-03-24-4bd19b16
     spec:
       affinity:
         podAntiAffinity:
@@ -51,7 +51,7 @@ spec:
         - --store=dnssrv+_grpc._tcp.observatorium-xyz-thanos-rule.observatorium.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.observatorium-xyz-thanos-store-shard-0.observatorium.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.observatorium-xyz-thanos-receive-default.observatorium.svc.cluster.local
-        image: quay.io/thanos/thanos:master-2020-02-13-adfef4b5
+        image: quay.io/thanos/thanos:master-2020-03-24-4bd19b16
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/environments/base/manifests/thanos-query-service.yaml
+++ b/environments/base/manifests/thanos-query-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
   name: observatorium-xyz-thanos-query
   namespace: observatorium
 spec:

--- a/environments/base/manifests/thanos-receive-default-service.yaml
+++ b/environments/base/manifests/thanos-receive-default-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-receive
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
     controller.receive.thanos.io/hashring: default
   name: observatorium-xyz-thanos-receive-default
   namespace: observatorium

--- a/environments/base/manifests/thanos-receive-default-statefulSet.yaml
+++ b/environments/base/manifests/thanos-receive-default-statefulSet.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-receive
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
     controller.receive.thanos.io: thanos-receive-controller
     controller.receive.thanos.io/hashring: default
   name: observatorium-xyz-thanos-receive-default
@@ -28,7 +28,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: thanos-receive
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: master-2020-02-13-adfef4b5
+        app.kubernetes.io/version: master-2020-03-24-4bd19b16
         controller.receive.thanos.io/hashring: default
     spec:
       affinity:
@@ -73,7 +73,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-02-13-adfef4b5
+        image: quay.io/thanos/thanos:master-2020-03-24-4bd19b16
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/environments/base/manifests/thanos-rule-service.yaml
+++ b/environments/base/manifests/thanos-rule-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-rule
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
   name: observatorium-xyz-thanos-rule
   namespace: observatorium
 spec:

--- a/environments/base/manifests/thanos-rule-statefulSet.yaml
+++ b/environments/base/manifests/thanos-rule-statefulSet.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-rule
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
   name: observatorium-xyz-thanos-rule
   namespace: observatorium
 spec:
@@ -25,7 +25,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: thanos-rule
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: master-2020-02-13-adfef4b5
+        app.kubernetes.io/version: master-2020-03-24-4bd19b16
     spec:
       containers:
       - args:
@@ -47,7 +47,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-02-13-adfef4b5
+        image: quay.io/thanos/thanos:master-2020-03-24-4bd19b16
         livenessProbe:
           failureThreshold: 24
           httpGet:

--- a/environments/base/manifests/thanos-store-shard0-service.yaml
+++ b/environments/base/manifests/thanos-store-shard0-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-store
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
     store.observatorium.io/shard: shard-0
   name: observatorium-xyz-thanos-store-shard-0
   namespace: observatorium

--- a/environments/base/manifests/thanos-store-shard0-statefulSet.yaml
+++ b/environments/base/manifests/thanos-store-shard0-statefulSet.yaml
@@ -38,6 +38,7 @@ spec:
         - --http-address=0.0.0.0:10902
         - --objstore.config=$(OBJSTORE_CONFIG)
         - --experimental.enable-index-header
+        - --ignore-deletion-marks-delay=1h
         - |
           --selector.relabel-config=
             - action: hashmod

--- a/environments/base/manifests/thanos-store-shard0-statefulSet.yaml
+++ b/environments/base/manifests/thanos-store-shard0-statefulSet.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-store
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
     store.observatorium.io/shard: shard-0
   name: observatorium-xyz-thanos-store-shard-0
   namespace: observatorium
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: thanos-store
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: master-2020-02-13-adfef4b5
+        app.kubernetes.io/version: master-2020-03-24-4bd19b16
         store.observatorium.io/shard: shard-0
     spec:
       containers:
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-02-13-adfef4b5
+        image: quay.io/thanos/thanos:master-2020-03-24-4bd19b16
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/environments/dev/manifests/api-gateway-thanos-query-deployment.yaml
+++ b/environments/dev/manifests/api-gateway-thanos-query-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz-api-gateway
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
   name: observatorium-xyz-observatorium-api-gateway-thanos-query
   namespace: observatorium
 spec:
@@ -24,7 +24,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz-api-gateway
         app.kubernetes.io/name: thanos-query
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: master-2020-02-13-adfef4b5
+        app.kubernetes.io/version: master-2020-03-24-4bd19b16
     spec:
       affinity:
         podAntiAffinity:
@@ -53,7 +53,7 @@ spec:
         - --store=dnssrv+_grpc._tcp.observatorium-xyz-thanos-store-shard-0.observatorium.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.observatorium-xyz-thanos-receive-default.observatorium.svc.cluster.local
         - --web.external-prefix=/ui/v1/metrics
-        image: quay.io/thanos/thanos:master-2020-02-13-adfef4b5
+        image: quay.io/thanos/thanos:master-2020-03-24-4bd19b16
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/environments/dev/manifests/api-gateway-thanos-query-service.yaml
+++ b/environments/dev/manifests/api-gateway-thanos-query-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz-api-gateway
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
   name: observatorium-xyz-observatorium-api-gateway-thanos-query
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/thanos-compact-service.yaml
+++ b/environments/dev/manifests/thanos-compact-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-compact
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
   name: observatorium-xyz-thanos-compact
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/thanos-compact-statefulSet.yaml
+++ b/environments/dev/manifests/thanos-compact-statefulSet.yaml
@@ -38,6 +38,7 @@ spec:
         - --retention.resolution-5m=1s
         - --retention.resolution-1h=1s
         - --downsampling.disable
+        - --delete-delay=4h
         - --deduplication.replica-label=prometheus_replica
         - --deduplication.replica-label=rule_replica
         - --deduplication.replica-label=replica

--- a/environments/dev/manifests/thanos-compact-statefulSet.yaml
+++ b/environments/dev/manifests/thanos-compact-statefulSet.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-compact
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
   name: observatorium-xyz-thanos-compact
   namespace: observatorium
 spec:
@@ -25,7 +25,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: thanos-compact
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: master-2020-02-13-adfef4b5
+        app.kubernetes.io/version: master-2020-03-24-4bd19b16
     spec:
       containers:
       - args:
@@ -44,7 +44,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-02-13-adfef4b5
+        image: quay.io/thanos/thanos:master-2020-03-24-4bd19b16
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/environments/dev/manifests/thanos-compact-statefulSet.yaml
+++ b/environments/dev/manifests/thanos-compact-statefulSet.yaml
@@ -38,6 +38,9 @@ spec:
         - --retention.resolution-5m=1s
         - --retention.resolution-1h=1s
         - --downsampling.disable
+        - --deduplication.replica-label=prometheus_replica
+        - --deduplication.replica-label=rule_replica
+        - --deduplication.replica-label=replica
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:

--- a/environments/dev/manifests/thanos-query-deployment.yaml
+++ b/environments/dev/manifests/thanos-query-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
   name: observatorium-xyz-thanos-query
   namespace: observatorium
 spec:
@@ -24,7 +24,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: thanos-query
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: master-2020-02-13-adfef4b5
+        app.kubernetes.io/version: master-2020-03-24-4bd19b16
     spec:
       affinity:
         podAntiAffinity:
@@ -51,7 +51,7 @@ spec:
         - --store=dnssrv+_grpc._tcp.observatorium-xyz-thanos-rule.observatorium.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.observatorium-xyz-thanos-store-shard-0.observatorium.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.observatorium-xyz-thanos-receive-default.observatorium.svc.cluster.local
-        image: quay.io/thanos/thanos:master-2020-02-13-adfef4b5
+        image: quay.io/thanos/thanos:master-2020-03-24-4bd19b16
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/environments/dev/manifests/thanos-query-service.yaml
+++ b/environments/dev/manifests/thanos-query-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
   name: observatorium-xyz-thanos-query
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/thanos-receive-default-service.yaml
+++ b/environments/dev/manifests/thanos-receive-default-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-receive
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
     controller.receive.thanos.io/hashring: default
   name: observatorium-xyz-thanos-receive-default
   namespace: observatorium

--- a/environments/dev/manifests/thanos-receive-default-statefulSet.yaml
+++ b/environments/dev/manifests/thanos-receive-default-statefulSet.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-receive
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
     controller.receive.thanos.io: thanos-receive-controller
     controller.receive.thanos.io/hashring: default
   name: observatorium-xyz-thanos-receive-default
@@ -28,7 +28,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: thanos-receive
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: master-2020-02-13-adfef4b5
+        app.kubernetes.io/version: master-2020-03-24-4bd19b16
         controller.receive.thanos.io/hashring: default
     spec:
       affinity:
@@ -73,7 +73,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-02-13-adfef4b5
+        image: quay.io/thanos/thanos:master-2020-03-24-4bd19b16
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/environments/dev/manifests/thanos-rule-service.yaml
+++ b/environments/dev/manifests/thanos-rule-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-rule
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
   name: observatorium-xyz-thanos-rule
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/thanos-rule-statefulSet.yaml
+++ b/environments/dev/manifests/thanos-rule-statefulSet.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-rule
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
   name: observatorium-xyz-thanos-rule
   namespace: observatorium
 spec:
@@ -25,7 +25,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: thanos-rule
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: master-2020-02-13-adfef4b5
+        app.kubernetes.io/version: master-2020-03-24-4bd19b16
     spec:
       containers:
       - args:
@@ -47,7 +47,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-02-13-adfef4b5
+        image: quay.io/thanos/thanos:master-2020-03-24-4bd19b16
         livenessProbe:
           failureThreshold: 24
           httpGet:

--- a/environments/dev/manifests/thanos-store-shard0-service.yaml
+++ b/environments/dev/manifests/thanos-store-shard0-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-store
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
     store.observatorium.io/shard: shard-0
   name: observatorium-xyz-thanos-store-shard-0
   namespace: observatorium

--- a/environments/dev/manifests/thanos-store-shard0-statefulSet.yaml
+++ b/environments/dev/manifests/thanos-store-shard0-statefulSet.yaml
@@ -38,6 +38,7 @@ spec:
         - --http-address=0.0.0.0:10902
         - --objstore.config=$(OBJSTORE_CONFIG)
         - --experimental.enable-index-header
+        - --ignore-deletion-marks-delay=1h
         - |
           --selector.relabel-config=
             - action: hashmod

--- a/environments/dev/manifests/thanos-store-shard0-statefulSet.yaml
+++ b/environments/dev/manifests/thanos-store-shard0-statefulSet.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-store
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-02-13-adfef4b5
+    app.kubernetes.io/version: master-2020-03-24-4bd19b16
     store.observatorium.io/shard: shard-0
   name: observatorium-xyz-thanos-store-shard-0
   namespace: observatorium
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: thanos-store
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: master-2020-02-13-adfef4b5
+        app.kubernetes.io/version: master-2020-03-24-4bd19b16
         store.observatorium.io/shard: shard-0
     spec:
       containers:
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-02-13-adfef4b5
+        image: quay.io/thanos/thanos:master-2020-03-24-4bd19b16
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -560,6 +560,7 @@ objects:
           - --retention.resolution-5m=1s
           - --retention.resolution-1h=1s
           - --downsampling.disable
+          - --delete-delay=4h
           - --deduplication.replica-label=prometheus_replica
           - --deduplication.replica-label=rule_replica
           - --deduplication.replica-label=replica
@@ -1513,6 +1514,7 @@ objects:
           - --http-address=0.0.0.0:10902
           - --objstore.config=$(OBJSTORE_CONFIG)
           - --experimental.enable-index-header
+          - --ignore-deletion-marks-delay=1h
           - |
             --selector.relabel-config=
               - action: hashmod
@@ -1699,6 +1701,7 @@ objects:
           - --http-address=0.0.0.0:10902
           - --objstore.config=$(OBJSTORE_CONFIG)
           - --experimental.enable-index-header
+          - --ignore-deletion-marks-delay=1h
           - |
             --selector.relabel-config=
               - action: hashmod
@@ -1885,6 +1888,7 @@ objects:
           - --http-address=0.0.0.0:10902
           - --objstore.config=$(OBJSTORE_CONFIG)
           - --experimental.enable-index-header
+          - --ignore-deletion-marks-delay=1h
           - |
             --selector.relabel-config=
               - action: hashmod

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -560,6 +560,9 @@ objects:
           - --retention.resolution-5m=1s
           - --retention.resolution-1h=1s
           - --downsampling.disable
+          - --deduplication.replica-label=prometheus_replica
+          - --deduplication.replica-label=rule_replica
+          - --deduplication.replica-label=replica
           - |
             --tracing.config=
               type: JAEGER

--- a/example/manifests/observatorium.yaml
+++ b/example/manifests/observatorium.yaml
@@ -56,8 +56,8 @@ spec:
         resources:
           requests:
             storage: 50Gi
-  thanosImage: quay.io/thanos/thanos:master-2020-02-13-adfef4b5
+  thanosImage: quay.io/thanos/thanos:master-2020-03-24-4bd19b16
   thanosReceiveController:
     image: quay.io/observatorium/thanos-receive-controller:master-2020-02-06-b66e0c8
     version: master-2020-02-06-b66e0c8
-  thanosVersion: master-2020-02-13-adfef4b5
+  thanosVersion: master-2020-03-24-4bd19b16

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -78,11 +78,11 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/thanos-io/kube-thanos",
+          "remote": "https://github.com/kakkoyun/kube-thanos",
           "subdir": "jsonnet/kube-thanos"
         }
       },
-      "version": "master"
+      "version": "dedup"
     },
     {
       "source": {

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -34,6 +34,16 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/kakkoyun/kube-thanos",
+          "subdir": "jsonnet/kube-thanos"
+        }
+      },
+      "version": "9aa36762f50fae8e47d2477cb51cb651a1d80c29",
+      "sum": "4c0Wj23A4gCjKB0LEQBlNmL1cNcntDvOg7b4fO4od8A="
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/ksonnet/ksonnet-lib",
           "subdir": ""
         }
@@ -93,16 +103,6 @@
       },
       "version": "fa41a6ae349cf5a54dd975703676bfad351992fb",
       "sum": "7N1rtI+xIs5b2itzPk/rvHlHkQ+94w1P9REcjlhbaDQ="
-    },
-    {
-      "source": {
-        "git": {
-          "remote": "https://github.com/thanos-io/kube-thanos",
-          "subdir": "jsonnet/kube-thanos"
-        }
-      },
-      "version": "5e7af669ee35af6c8beaa37e7a30d865368d75d8",
-      "sum": "kyza6itqcvQHoKeJqsFjFQuMpj8RZsudC5/2vVxw5R0="
     },
     {
       "source": {


### PR DESCRIPTION
This PR depends on the latest version of Thanos and kube-thanos.
xref: https://github.com/thanos-io/kube-thanos/pull/105

# Changes
* Upgrade to [the latest Thanos version](https://quay.io/repository/thanos/thanos/manifest/sha256:49275de06d3bed2729dbe8a8fa34bc5307151c979cc54b75c004d3f987424cd6) bed5536a435535c6a75db63f68f61093e6e99813
* Add deduplication replica label flags daca967a6e36765ab9d0628bbb3f283034f2e461
* Add delete delay flags 57f99e9a2cbf2b6a27a07b8a2960fa0671e30f7b