### PR TITLE
Enable offline deduplication

### DIFF
--- a/components/observatorium.libsonnet
+++ b/components/observatorium.libsonnet
@@ -17,6 +17,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     t.compact +
     t.compact.withRetention +
     t.compact.withDownsamplingDisabled +
+    t.compact.withDeleteDelay +
     t.compact.withDeduplication + {
       config+:: {
         local cfg = self,
@@ -25,6 +26,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         replicas: 1,
         commonLabels+:: obs.config.commonLabels,
         deduplicationReplicaLabels: obs.config.deduplicationReplicaLabels,
+        deleteDelay: '48h',
       },
     },
 
@@ -79,7 +81,8 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
 
   store:: {
     ['shard' + i]:
-      t.store {
+      t.store +
+      t.store.withIgnoreDeletionMarksDelay {
         config+:: {
           local cfg = self,
           name: obs.config.name + '-' + cfg.commonLabels['app.kubernetes.io/name'] + '-shard-' + i,
@@ -88,6 +91,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
             'store.observatorium.io/shard': 'shard-' + i,
           },
           replicas: 1,
+          ignoreDeletionMarksDelay: '24h',
         },
       } + {
         statefulSet+: {

--- a/components/observatorium.libsonnet
+++ b/components/observatorium.libsonnet
@@ -9,18 +9,22 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       'app.kubernetes.io/part-of': 'observatorium',
       'app.kubernetes.io/instance': obs.config.name,
     },
+    replicaLabels:: ['prometheus_replica', 'rule_replica', 'replica'],
+    deduplicationReplicaLabels:: ['replica'],
   },
 
   compact::
     t.compact +
     t.compact.withRetention +
-    t.compact.withDownsamplingDisabled + {
+    t.compact.withDownsamplingDisabled +
+    t.compact.withDeduplication + {
       config+:: {
         local cfg = self,
         name: obs.config.name + '-' + cfg.commonLabels['app.kubernetes.io/name'],
         namespace: obs.config.namespace,
         replicas: 1,
         commonLabels+:: obs.config.commonLabels,
+        deduplicationReplicaLabels: obs.config.deduplicationReplicaLabels,
       },
     },
 
@@ -129,7 +133,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           [obs.store[shard].service for shard in std.objectFields(obs.store)] +
           [obs.receivers[hashring].service for hashring in std.objectFields(obs.receivers)]
       ],
-      replicaLabels: ['prometheus_replica', 'rule_replica', 'replica'],
+      replicaLabels: obs.config.replicaLabels,
     },
   },
 

--- a/environments/base/manifests/thanos-compact-statefulSet.yaml
+++ b/environments/base/manifests/thanos-compact-statefulSet.yaml
@@ -38,6 +38,7 @@ spec:
         - --retention.resolution-5m=1s
         - --retention.resolution-1h=1s
         - --downsampling.disable
+        - --deduplication.replica-label=replica
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:

--- a/environments/base/manifests/thanos-compact-statefulSet.yaml
+++ b/environments/base/manifests/thanos-compact-statefulSet.yaml
@@ -38,6 +38,7 @@ spec:
         - --retention.resolution-5m=1s
         - --retention.resolution-1h=1s
         - --downsampling.disable
+        - --delete-delay=48h
         - --deduplication.replica-label=replica
         env:
         - name: OBJSTORE_CONFIG

--- a/environments/base/manifests/thanos-store-shard0-statefulSet.yaml
+++ b/environments/base/manifests/thanos-store-shard0-statefulSet.yaml
@@ -38,6 +38,7 @@ spec:
         - --http-address=0.0.0.0:10902
         - --objstore.config=$(OBJSTORE_CONFIG)
         - --experimental.enable-index-header
+        - --ignore-deletion-marks-delay=24h
         - |
           --selector.relabel-config=
             - action: hashmod

--- a/environments/dev/manifests/thanos-compact-statefulSet.yaml
+++ b/environments/dev/manifests/thanos-compact-statefulSet.yaml
@@ -38,6 +38,7 @@ spec:
         - --retention.resolution-5m=1s
         - --retention.resolution-1h=1s
         - --downsampling.disable
+        - --deduplication.replica-label=replica
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:

--- a/environments/dev/manifests/thanos-compact-statefulSet.yaml
+++ b/environments/dev/manifests/thanos-compact-statefulSet.yaml
@@ -38,6 +38,7 @@ spec:
         - --retention.resolution-5m=1s
         - --retention.resolution-1h=1s
         - --downsampling.disable
+        - --delete-delay=48h
         - --deduplication.replica-label=replica
         env:
         - name: OBJSTORE_CONFIG

--- a/environments/dev/manifests/thanos-store-shard0-statefulSet.yaml
+++ b/environments/dev/manifests/thanos-store-shard0-statefulSet.yaml
@@ -38,6 +38,7 @@ spec:
         - --http-address=0.0.0.0:10902
         - --objstore.config=$(OBJSTORE_CONFIG)
         - --experimental.enable-index-header
+        - --ignore-deletion-marks-delay=24h
         - |
           --selector.relabel-config=
             - action: hashmod

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -560,6 +560,7 @@ objects:
           - --retention.resolution-5m=1s
           - --retention.resolution-1h=1s
           - --downsampling.disable
+          - --deduplication.replica-label=replica
           - |
             --tracing.config=
               type: JAEGER

--- a/environments/openshift/manifests/observatorium-template.yaml
+++ b/environments/openshift/manifests/observatorium-template.yaml
@@ -560,6 +560,7 @@ objects:
           - --retention.resolution-5m=1s
           - --retention.resolution-1h=1s
           - --downsampling.disable
+          - --delete-delay=48h
           - --deduplication.replica-label=replica
           - |
             --tracing.config=
@@ -1511,6 +1512,7 @@ objects:
           - --http-address=0.0.0.0:10902
           - --objstore.config=$(OBJSTORE_CONFIG)
           - --experimental.enable-index-header
+          - --ignore-deletion-marks-delay=24h
           - |
             --selector.relabel-config=
               - action: hashmod
@@ -1697,6 +1699,7 @@ objects:
           - --http-address=0.0.0.0:10902
           - --objstore.config=$(OBJSTORE_CONFIG)
           - --experimental.enable-index-header
+          - --ignore-deletion-marks-delay=24h
           - |
             --selector.relabel-config=
               - action: hashmod
@@ -1883,6 +1886,7 @@ objects:
           - --http-address=0.0.0.0:10902
           - --objstore.config=$(OBJSTORE_CONFIG)
           - --experimental.enable-index-header
+          - --ignore-deletion-marks-delay=24h
           - |
             --selector.relabel-config=
               - action: hashmod

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -101,8 +101,8 @@
           "subdir": "jsonnet/kube-thanos"
         }
       },
-      "version": "5e7af669ee35af6c8beaa37e7a30d865368d75d8",
-      "sum": "kyza6itqcvQHoKeJqsFjFQuMpj8RZsudC5/2vVxw5R0="
+      "version": "00fe1af48041e136b81b20f179dbb63b1fffc57e",
+      "sum": "4c0Wj23A4gCjKB0LEQBlNmL1cNcntDvOg7b4fO4od8A="
     },
     {
       "source": {


### PR DESCRIPTION
This PR depends on the latest version of Thanos and kube-thanos.
Depends: https://github.com/observatorium/configuration/pull/222
xref: https://github.com/thanos-io/kube-thanos/pull/105

About flags:
```
--delete-delay=48h

Time before a block marked for deletion is deleted from bucket.

If delete-delay is non zero, blocks will be marked for deletion 
and compactor component will delete blocks marked for deletion from the bucket.

If delete-delay is 0, blocks will be deleted straight away.
Use this if you want to get rid of or move the block immediately.

Note that deleting blocks immediately can cause query failures, 
if store gateway still has the block loaded, or compactor is ignoring the deletion 
because it's compacting the block at the same time.
```
```
--ignore-deletion-marks-delay=24h

Duration after which the blocks marked for deletion will be filtered out while fetching blocks.
The idea of ignore-deletion-marks-delay is to ignore blocks that are marked for deletion with some delay. 

This ensures store can still serve blocks that are meant to be deleted but do not have a replacement yet. 
If delete-delay duration is provided to compactor or bucket verify component, 
it will upload deletion-mark.json file to mark after what duration the block should be deleted rather than deleting the block straight away.

If delete-delay is non-zero for compactor or bucket verify component, 
ignore-deletion-marks-delay should be set to (delete-delay)/2 so that blocks marked for deletion are filtered out while fetching blocks before being deleted from bucket. 
Default is 24h, half of the default value for --delete-delay on compactor.
```
# Changes
* Add deduplication replica label flags daca967a6e36765ab9d0628bbb3f283034f2e461
* Add delete delay flags 57f99e9a2cbf2b6a27a07b8a2960fa0671e30f7b