### PR TITLE
components/jaeger-collector: move to memory store

### DIFF
--- a/components/jaeger-collector.libsonnet
+++ b/components/jaeger-collector.libsonnet
@@ -76,20 +76,13 @@ local jaegerAgent = import './jaeger-agent.libsonnet';
       local mount = container.volumeMountsType;
       local volume = k.apps.v1.statefulSet.mixin.spec.template.spec.volumesType;
 
-      // the assumption based on past perf tests is that this collector should be able to comfortably
-      // ingest at least 2k spans/sec with badger and 256Mi of memory on 1 cpu.
-      // this depends on the span size, but these default values should provide a good base line
       local c =
         container.new($.jaeger.deployment.metadata.name, j.image) +
         container.withArgs([
-          '--badger.directory-key=/var/jaeger/store/keys',
-          '--badger.directory-value=/var/jaeger/store/values',
-          '--badger.ephemeral=false',
-          '--badger.span-store-ttl=3h',
           '--collector.queue-size=4000',
         ],) +
         container.withEnv([
-          env.new('SPAN_STORAGE_TYPE', 'badger'),
+          env.new('SPAN_STORAGE_TYPE', 'memory'),
         ]) + container.withPorts(
           [
             containerPort.newNamed(14250, 'grpc'),

--- a/environments/openshift/jaeger.jsonnet
+++ b/environments/openshift/jaeger.jsonnet
@@ -44,6 +44,9 @@ local app =
                       memory: '${JAEGER_MEMORY_LIMITS}',
                     },
                   },
+                  args+: [
+                    '--memory.max-trace=${JAEGER_MAX_TRACE}',
+                  ],
                 },
               ] + [
                 container.new('proxy', '${PROXY_IMAGE}:${PROXY_IMAGE_TAG}') +
@@ -120,5 +123,6 @@ local app =
     { name: 'JAEGER_PROXY_MEMORY_REQUEST', value: '100Mi' },
     { name: 'JAEGER_PROXY_CPU_LIMITS', value: '200m' },
     { name: 'JAEGER_PROXY_MEMORY_LIMITS', value: '200Mi' },
+    { name: 'JAEGER_MAX_TRACE', value: '100000' },
   ],
 }

--- a/environments/openshift/manifests/jaeger-template.yaml
+++ b/environments/openshift/manifests/jaeger-template.yaml
@@ -54,14 +54,11 @@ objects:
       spec:
         containers:
         - args:
-          - --badger.directory-key=/var/jaeger/store/keys
-          - --badger.directory-value=/var/jaeger/store/values
-          - --badger.ephemeral=false
-          - --badger.span-store-ttl=3h
           - --collector.queue-size=4000
+          - --memory.max-trace=${JAEGER_MAX_TRACE}
           env:
           - name: SPAN_STORAGE_TYPE
-            value: badger
+            value: memory
           image: ${IMAGE}:${IMAGE_TAG}
           livenessProbe:
             failureThreshold: 4
@@ -313,3 +310,5 @@ parameters:
   value: 200m
 - name: JAEGER_PROXY_MEMORY_LIMITS
   value: 200Mi
+- name: JAEGER_MAX_TRACE
+  value: "100000"


### PR DESCRIPTION
This commit reconfigures Jaeger to use its in-memory store rather than
Badger, due to performance and operational issues we have been having in
production. Note that unlike Badger, the in-memory store does not
support time-based retention; instead it only supports limiting the
total number of traces. This limit is parameterized as an OpenShift
template variable.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @brancz @metalmatze @jpkrohling 

PS: is 100k a sane limit? Or is this too high/will this require too much memory?