### PR TITLE
environments/openshift: fix jaeger flag

### DIFF
--- a/environments/openshift/jaeger.jsonnet
+++ b/environments/openshift/jaeger.jsonnet
@@ -45,7 +45,7 @@ local app =
                     },
                   },
                   args+: [
-                    '--memory.max-trace=${JAEGER_MAX_TRACE}',
+                    '--memory.max-traces=${JAEGER_MAX_TRACES}',
                   ],
                 },
               ] + [
@@ -123,6 +123,6 @@ local app =
     { name: 'JAEGER_PROXY_MEMORY_REQUEST', value: '100Mi' },
     { name: 'JAEGER_PROXY_CPU_LIMITS', value: '200m' },
     { name: 'JAEGER_PROXY_MEMORY_LIMITS', value: '200Mi' },
-    { name: 'JAEGER_MAX_TRACE', value: '100000' },
+    { name: 'JAEGER_MAX_TRACES', value: '100000' },
   ],
 }

--- a/environments/openshift/manifests/jaeger-template.yaml
+++ b/environments/openshift/manifests/jaeger-template.yaml
@@ -55,7 +55,7 @@ objects:
         containers:
         - args:
           - --collector.queue-size=4000
-          - --memory.max-trace=${JAEGER_MAX_TRACE}
+          - --memory.max-traces=${JAEGER_MAX_TRACES}
           env:
           - name: SPAN_STORAGE_TYPE
             value: memory
@@ -310,5 +310,5 @@ parameters:
   value: 200m
 - name: JAEGER_PROXY_MEMORY_LIMITS
   value: 200Mi
-- name: JAEGER_MAX_TRACE
+- name: JAEGER_MAX_TRACES
   value: "100000"


### PR DESCRIPTION
This commit fixes the `--memory.max-traces` flag on the Jaeger
deployment.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>