### PR TITLE
.circleci: simplify config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,11 +40,6 @@ jobs:
 
 workflows:
   version: 2
-  build_and_test:
-    jobs:
-      - build
-      - tests
-      - test-operator
   tagged-master:
     jobs:
       - container-push:
@@ -54,7 +49,7 @@ workflows:
             branches:
               only:
                 - master
-  commit-master:
+  test-and-push:
     jobs:
       - build
       - tests


### PR DESCRIPTION
This commit de-duplicated the CircleCI configuration so that the build
and test jobs are not run twice for every single PR.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>