### PR TITLE
Set labels properly on the sample CR

### DIFF
--- a/example/main.jsonnet
+++ b/example/main.jsonnet
@@ -6,10 +6,12 @@ local obs = (import '../environments/base/observatorium.jsonnet');
 
   apiVersion: 'core.observatorium.io/v1alpha1',
   kind: 'Observatorium',
-  metadata: obs.config.commonLabels {
+  metadata: {
     name: obs.config.name,
-    'app.kubernetes.io/name': cr.name,
-    'app.kubernetes.io/component': cr.name,
+    labels: obs.config.commonLabels {
+      'app.kubernetes.io/name': cr.name,
+      'app.kubernetes.io/component': cr.name,
+    },
   },
   spec: {
     objectStorageConfig: obs.config.objectStorageConfig,

--- a/example/manifests/observatorium.yaml
+++ b/example/manifests/observatorium.yaml
@@ -1,10 +1,11 @@
 apiVersion: core.observatorium.io/v1alpha1
 kind: Observatorium
 metadata:
-  app.kubernetes.io/component: observatorium-cr
-  app.kubernetes.io/instance: observatorium-xyz
-  app.kubernetes.io/name: observatorium-cr
-  app.kubernetes.io/part-of: observatorium
+  labels:
+    app.kubernetes.io/component: observatorium-cr
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: observatorium-cr
+    app.kubernetes.io/part-of: observatorium
   name: observatorium-xyz
 spec:
   api:


### PR DESCRIPTION
The following keys in the metadata are currently ignored:
app.kubernetes.io/component
app.kubernetes.io/instance
app.kubernetes.io/name
app.kubernetes.io/part-of
this PR moves them to metadata.labels