### PR TITLE
Adapt tests script for macOS

### DIFF
--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -4,10 +4,11 @@ set -e
 set -o pipefail
 
 KUBECTL="${KUBECTL:-./kubectl}"
+OS_TYPE=$(echo `uname -s` | tr '[:upper:]' '[:lower:]')
 
 kind() {
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/"$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)"/bin/linux/amd64/kubectl
-    curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-amd64
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/"$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)"/bin/$OS_TYPE/amd64/kubectl
+    curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-$OS_TYPE-amd64
     chmod +x kind kubectl
     ./kind create cluster
 }


### PR DESCRIPTION
Currently, the e2e.sh tests script downloads both kind
and kubctl binaries for Linux.

Developers (myself included) might want to test locally,
and this will not work correctly under macOS (Darwin).

This patch will improve e2e.sh and allow it to download
the binaries that match the operating system.