### PR TITLE
queries-file container flag bug

### DIFF
--- a/components/up.libsonnet
+++ b/components/up.libsonnet
@@ -57,9 +57,12 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       container.withArgs(
         [
           '--duration=0',
-          '--queries-file=/etc/up/queries.yaml',
           '--log.level=debug',
         ] + (
+          if up.config.queryConfig != {} then
+            ['--queries-file=/etc/up/queries.yaml']
+          else []
+        ) + (
           if up.config.readEndpoint != '' then
             ['--endpoint-read=' + up.config.readEndpoint]
           else []

--- a/environments/dev/manifests/up-deployment.yaml
+++ b/environments/dev/manifests/up-deployment.yaml
@@ -23,7 +23,6 @@ spec:
       containers:
       - args:
         - --duration=0
-        - --queries-file=/etc/up/queries.yaml
         - --log.level=debug
         - --endpoint-read=http://observatorium-xyz-cortex-query-frontend.observatorium.svc:9090/api/v1/query
         - --endpoint-write=http://observatorium-xyz-cortex-query-frontend.observatorium.svc:9090/api/v1/query


### PR DESCRIPTION
The queries-file flag should be provided only when present in the config.

fixes https://github.com/observatorium/configuration/issues/285

cc @metalmatze , @brancz 

Signed-off-by: Krasi Georgiev <8903888+krasi-georgiev@users.noreply.github.com>